### PR TITLE
Prepare Susanin v0.11.4-rc1 release candidate

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,3 +12,5 @@ src/*.o
 .gitignore
 susanin-secrets
 secrets
+
+dist-dev/

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -11,7 +11,7 @@ body:
     id: version
     attributes:
       label: Susanin version
-      placeholder: 0.11.3
+      placeholder: 0.11.4-rc1
     validations:
       required: true
   - type: input

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Existing tag/release to build (example: v0.11.3)'
+        description: 'Existing tag/release to build (example: v0.11.4-rc1)'
         required: true
 
 permissions:
@@ -25,26 +25,124 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.inputs.tag || github.ref }}
 
+      - name: Validate release version plumbing
+        shell: bash
+        env:
+          TAG: ${{ github.event.inputs.tag || github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
+            echo "ERROR: invalid release tag: $TAG"
+            exit 1
+          fi
+
+          VERSION="${TAG#v}"
+
+          SOURCE_VERSION="$(
+            sed -nE 's/^#define SUSANIN_VERSION "([^"]+)"$/\1/p' src/version.h
+          )"
+
+          BOOTSTRAP_HEADER_VERSION="$(
+            sed -nE 's/^# Susanin v([^ ]+) credentialless bootstrap$/\1/p' bootstrap/install.rsc
+          )"
+
+          BOOTSTRAP_TAG_VERSION="$(
+            sed -nE 's/.*\$susaninBootstrapTag != "([^"]+)".*/\1/p' bootstrap/install.rsc
+          )"
+
+          ROOT_TOKEN="$(
+            printf '%s' "$VERSION" | tr -cd '[:alnum:]'
+          )"
+          EXPECTED_ROOT="/susanin-controller-v${ROOT_TOKEN}"
+
+          BOOTSTRAP_ROOTS="$(
+            grep -oE '/susanin-controller-v[[:alnum:]]+' bootstrap/install.rsc \
+              | sort -u || true
+          )"
+
+          ROOT_COUNT="$(
+            printf '%s\n' "$BOOTSTRAP_ROOTS" \
+              | sed '/^$/d' \
+              | wc -l \
+              | tr -d ' '
+          )"
+
+          echo "Release tag              : $TAG"
+          echo "Release version          : $VERSION"
+          echo "Source version           : $SOURCE_VERSION"
+          echo "Bootstrap header version : $BOOTSTRAP_HEADER_VERSION"
+          echo "Bootstrap expected tag   : $BOOTSTRAP_TAG_VERSION"
+          echo "Expected root-dir        : $EXPECTED_ROOT"
+          echo "Bootstrap root-dir(s)    :"
+          printf '%s\n' "$BOOTSTRAP_ROOTS"
+
+          if [[ "$SOURCE_VERSION" != "$VERSION" ]]; then
+            echo "ERROR: src/version.h does not match release tag"
+            exit 1
+          fi
+
+          if [[ "$BOOTSTRAP_HEADER_VERSION" != "$VERSION" ]]; then
+            echo "ERROR: bootstrap header does not match release tag"
+            exit 1
+          fi
+
+          if [[ "$BOOTSTRAP_TAG_VERSION" != "$VERSION" ]]; then
+            echo "ERROR: bootstrap expected image tag does not match release tag"
+            exit 1
+          fi
+
+          if [[ "$ROOT_COUNT" != "1" ]]; then
+            echo "ERROR: bootstrap must contain exactly one unique versioned root-dir"
+            exit 1
+          fi
+
+          if [[ "$BOOTSTRAP_ROOTS" != "$EXPECTED_ROOT" ]]; then
+            echo "ERROR: bootstrap root-dir does not match release version"
+            exit 1
+          fi
+
+          if grep -nE ':return([;}[:space:]]|$)' bootstrap/install.rsc; then
+            echo "ERROR: bare :return found in bootstrap/install.rsc"
+            exit 1
+          fi
+
+          echo "PASS: release version plumbing is consistent"
+
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
 
       - name: Build RouterOS ARM64 image
         shell: bash
+        env:
+          TAG: ${{ github.event.inputs.tag || github.ref_name }}
         run: |
           set -euxo pipefail
-          TAG='${{ github.event.inputs.tag || github.ref_name }}'
+
           VERSION="${TAG#v}"
+
           mkdir -p dist
+
           docker buildx build \
             --platform linux/arm64 \
             --no-cache \
             -t "susanin:${VERSION}" \
             --output type=docker,dest=dist/susanin.tar \
             .
+
           cp bootstrap/install.rsc dist/install.rsc
           cp bootstrap/uninstall.rsc dist/uninstall.rsc
           cp bootstrap/uninstall-controller.rsc dist/uninstall-controller.rsc
-          (cd dist && sha256sum susanin.tar install.rsc uninstall.rsc uninstall-controller.rsc > SHA256SUMS)
+
+          (
+            cd dist
+            sha256sum \
+              susanin.tar \
+              install.rsc \
+              uninstall.rsc \
+              uninstall-controller.rsc \
+              > SHA256SUMS
+          )
 
       - name: Create/attach prerelease
         env:
@@ -52,5 +150,9 @@ jobs:
           TAG: ${{ github.event.inputs.tag || github.ref_name }}
         run: |
           gh release view "$TAG" >/dev/null 2>&1 \
-            || gh release create "$TAG" --title "$TAG — pilot" --generate-notes --prerelease
+            || gh release create "$TAG" \
+                 --title "$TAG — pilot" \
+                 --generate-notes \
+                 --prerelease
+
           gh release upload "$TAG" dist/* --clobber

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ src/*.o
 secrets/
 susanin-secrets/
 .DS_Store
+
+dist-dev/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## v0.11.4-rc1 — release candidate
+
+Release candidate preparation after the v0.11.3 public pilot baseline.
+
+Highlights:
+
+- persistent runtime configuration in `/data/susanin.conf`;
+- configurable RouterOS log levels;
+- diagnostic recorder with bounded rotation;
+- RouterOS resource and script-job telemetry;
+- RouterOS log diagnostics through `diag errors`;
+- safer RouterOS script termination using `:exit`;
+- transient RouterOS address-list object race protection;
+- release workflow version consistency validation.
+
+### Validation performed
+
+- ARM64 MikroTik reference platform;
+- RouterOS 7.23.3;
+- existing route-based WireGuard/AmneziaWG egress preserved;
+- clean uninstall of v0.11.3 from restored configuration;
+- Susanin-owned objects removed without affecting external VPN routing;
+- diagnostics, telemetry and staged update workflow tested.
+
+### Known limitations
+
+- ARM64 remains the public target;
+- RouterOS 7.23.3 is the reference validation platform;
+- IPv4 only;
+- `no such item (4)` from dynamic `/ip firewall connection` access remains under investigation;
+- final GitHub-built RC artifact installation is still pending.
+
 ## v0.11.3 — pilot public baseline
 
 First public pilot candidate proven on a real ARM64 MikroTik / RouterOS 7.23.3.

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ CFLAGS ?= -O2 -pipe -std=c11 -Wall -Wextra -Wpedantic -Werror
 CPPFLAGS ?= -Isrc
 LDFLAGS ?=
 
-SRC := src/main.c src/routeros_api.c src/config.c src/discovery.c src/status.c src/apply.c src/fingerprint.c src/snapshot.c src/renderer.c src/validate.c src/stage.c src/promote.c src/setup.c src/install.c
+SRC := src/main.c src/routeros_api.c src/config.c src/diag.c src/discovery.c src/status.c src/apply.c src/fingerprint.c src/snapshot.c src/renderer.c src/validate.c src/stage.c src/promote.c src/setup.c src/install.c
 OBJ := $(SRC:.c=.o)
 BIN := susanin
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ CFLAGS ?= -O2 -pipe -std=c11 -Wall -Wextra -Wpedantic -Werror
 CPPFLAGS ?= -Isrc
 LDFLAGS ?=
 
-SRC := src/main.c src/routeros_api.c src/config.c src/diag.c src/telemetry.c src/discovery.c src/status.c src/apply.c src/fingerprint.c src/snapshot.c src/renderer.c src/validate.c src/stage.c src/promote.c src/setup.c src/install.c
+SRC := src/main.c src/routeros_api.c src/config.c src/diag.c src/telemetry.c src/routerlog.c src/discovery.c src/status.c src/apply.c src/fingerprint.c src/snapshot.c src/renderer.c src/validate.c src/stage.c src/promote.c src/setup.c src/install.c
 OBJ := $(SRC:.c=.o)
 BIN := susanin
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ CFLAGS ?= -O2 -pipe -std=c11 -Wall -Wextra -Wpedantic -Werror
 CPPFLAGS ?= -Isrc
 LDFLAGS ?=
 
-SRC := src/main.c src/routeros_api.c src/config.c src/diag.c src/discovery.c src/status.c src/apply.c src/fingerprint.c src/snapshot.c src/renderer.c src/validate.c src/stage.c src/promote.c src/setup.c src/install.c
+SRC := src/main.c src/routeros_api.c src/config.c src/diag.c src/telemetry.c src/discovery.c src/status.c src/apply.c src/fingerprint.c src/snapshot.c src/renderer.c src/validate.c src/stage.c src/promote.c src/setup.c src/install.c
 OBJ := $(SRC:.c=.o)
 BIN := susanin
 

--- a/README.md
+++ b/README.md
@@ -715,7 +715,7 @@ docker buildx build \
   --builder way-builder \
   --platform linux/arm64 \
   --no-cache \
-  -t susanin:0.11.3 \
+  -t susanin:local \
   --output type=docker,dest=susanin.tar \
   .
 ```
@@ -724,8 +724,8 @@ docker buildx build \
 
 ```bash
 docker load -i susanin.tar
-docker image inspect susanin:0.11.3 --format '{{.Os}}/{{.Architecture}}'
-docker run --rm --platform linux/arm64 susanin:0.11.3 version
+docker image inspect susanin:local --format '{{.Os}}/{{.Architecture}}'
+docker run --rm --platform linux/arm64 susanin:local version
 ```
 
 Нативная C-сборка:

--- a/bootstrap/install.rsc
+++ b/bootstrap/install.rsc
@@ -1,4 +1,4 @@
-# Susanin v0.11.3 credentialless bootstrap
+# Susanin v0.11.4-rc1 credentialless bootstrap
 # Requires the architecture-matching container image uploaded as susanin.tar.
 # No username/password input and no environment list are required.
 # Controller network: 172.31.254.0/30 (RouterOS .1, Susanin .2).
@@ -81,14 +81,14 @@
         # versioned root-dir, otherwise the worker would mistake it for an old
         # container and continuously delete/re-add it.
         :local susaninBootstrapRoot [:tostr [/container get [find where name="susanin-controller"] root-dir]]
-        :if ($susaninBootstrapRoot = "/susanin-controller-v0113") do={
+        :if ($susaninBootstrapRoot = "/susanin-controller-v0114rc1") do={
             :local susaninBootstrapArch [:tostr [/container get [find where name="susanin-controller"] arch]]
-            :if ($susaninBootstrapArch = "") do={ :return }
+            :if ($susaninBootstrapArch = "") do={ :exit }
             :local susaninBootstrapTag [:tostr [/container get [find where name="susanin-controller"] tag]]
-            :if ($susaninBootstrapTag != "0.11.3") do={
+            :if ($susaninBootstrapTag != "0.11.4-rc1") do={
                 /system scheduler disable [find where name="susanin-bootstrap-worker"]
-                :log error ("SUSANIN: extracted image tag mismatch, expected 0.11.3 got " . $susaninBootstrapTag)
-                :return
+                :log error ("SUSANIN: extracted image tag mismatch, expected 0.11.4-rc1 got " . $susaninBootstrapTag)
+                :exit
             }
 
             :local susaninStartOK true
@@ -98,7 +98,7 @@
                 :set susaninStartOK false
                 :log warning ("SUSANIN: bootstrap start returned error; will retry: " . $susaninStartError)
             }
-            :if ($susaninStartOK = false) do={ :return }
+            :if ($susaninStartOK = false) do={ :exit }
 
             # The bootstrap worker carries temporary elevated policies. Do not
             # leave it behind for the restricted susanin-agent to clean up later:
@@ -107,7 +107,7 @@
             /system scheduler add name="susanin-bootstrap-cleanup" interval=2s policy=read,write,policy,test,password comment="SUSANIN: one-shot bootstrap helper cleanup" on-event=":delay 1s; /system scheduler remove [find where name=\"susanin-bootstrap-worker\"]; /system script remove [find where name=\"susanin-bootstrap-worker\"]; /system scheduler remove [find where name=\"susanin-bootstrap-cleanup\"]"
             /system scheduler disable [find where name="susanin-bootstrap-worker"]
             :log info "SUSANIN: controller bootstrap finished; helper cleanup queued"
-            :return
+            :exit
         }
 
         # A different root-dir belongs to an older Susanin controller. It is
@@ -117,7 +117,7 @@
         :delay 1s
         :onerror susaninRemoveError in={ /container remove [find where name="susanin-controller"] } do={}
         :delay 1s
-        :if ([:len [/container find where name="susanin-controller"]] > 0) do={ :return }
+        :if ([:len [/container find where name="susanin-controller"]] > 0) do={ :exit }
     }
 
     # Detach old consumers before rotating the machine credential.
@@ -140,7 +140,7 @@
     :local susaninWrittenPassword [/file get [find where name="susanin-secrets/routeros_password"] contents as-string]
     :if (($susaninWrittenSize != 48) || ([:len $susaninWrittenPassword] != 48) || ($susaninWrittenPassword != $susaninGeneratedPassword)) do={
         :log error "SUSANIN: secret verification failed; agent password was NOT changed"
-        :return
+        :exit
     }
 
     # Synchronize the restricted RouterOS machine identity only after successful
@@ -155,10 +155,10 @@
     /container mounts add list=susanin-data src=susanin-data dst=/data
 
     :onerror susaninContainerAddError in={
-        /container add file=susanin.tar interface=veth-susanin root-dir=/susanin-controller-v0113 mountlists=susanin-secret,susanin-data name=susanin-controller logging=yes start-on-boot=yes cmd=daemon
+        /container add file=susanin.tar interface=veth-susanin root-dir=/susanin-controller-v0114rc1 mountlists=susanin-secret,susanin-data name=susanin-controller logging=yes start-on-boot=yes cmd=daemon
     } do={
         :log error ("SUSANIN: container add failed: " . $susaninContainerAddError)
-        :return
+        :exit
     }
     :log info "SUSANIN: container queued for extraction"
 }

--- a/bootstrap/uninstall-controller.rsc
+++ b/bootstrap/uninstall-controller.rsc
@@ -1,4 +1,4 @@
-# Susanin v0.11.3 controller-only cleanup.
+# Susanin v0.11.4-rc1 controller-only cleanup.
 # Keeps the RouterOS adaptive routing data-plane intact.
 
 /system scheduler remove [find where name~"susanin-bootstrap-"]

--- a/bootstrap/uninstall.rsc
+++ b/bootstrap/uninstall.rsc
@@ -1,4 +1,4 @@
-# Susanin v0.11.3 full uninstall.
+# Susanin v0.11.4-rc1 full uninstall.
 # Removes Susanin controller + Susanin-managed adaptive routing data-plane.
 # Does NOT remove the selected VPN/tunnel itself.
 

--- a/docs/RELEASE_NOTES_v0.11.4.md
+++ b/docs/RELEASE_NOTES_v0.11.4.md
@@ -1,0 +1,39 @@
+# Susanin v0.11.4-rc1 — release candidate draft
+
+## Status
+
+Release candidate preparation branch.
+
+This document describes the changes accumulated after the v0.11.3 pilot baseline.
+
+## Highlights
+
+- persistent runtime configuration in `/data/susanin.conf`;
+- configurable RouterOS log levels;
+- diagnostic recorder with rotation;
+- RouterOS telemetry collection from the controller;
+- RouterOS script error diagnostics via `diag errors`;
+- safer RouterOS script termination handling;
+- protection against transient RouterOS address-list object races.
+
+## Validation performed
+
+Reference test platform:
+
+- MikroTik ARM64;
+- RouterOS 7.23.3;
+- route-based AmneziaWG/WireGuard egress.
+
+Verified scenarios:
+
+- clean uninstall of the v0.11.3 controller while preserving external VPN data plane;
+- clean RouterOS state after uninstall;
+- fresh ARM64 container build;
+- diagnostics start/stop/sample/error reporting;
+- stage/validate/promote workflow.
+
+## Known limitations
+
+- ARM64 remains the public target;
+- RouterOS 7.23.3 is the reference validation platform;
+- `no such item (4)` from dynamic `/ip firewall connection` access remains tracked as a RouterOS interaction issue and is not considered fully solved in this release candidate.

--- a/docs/RELEASE_NOTES_v0.11.4.md
+++ b/docs/RELEASE_NOTES_v0.11.4.md
@@ -37,3 +37,29 @@ Verified scenarios:
 - ARM64 remains the public target;
 - RouterOS 7.23.3 is the reference validation platform;
 - `no such item (4)` from dynamic `/ip firewall connection` access remains tracked as a RouterOS interaction issue and is not considered fully solved in this release candidate.
+
+## Field validation of the published RC
+
+The exact GitHub-generated `v0.11.4-rc1` artifacts were validated on the ARM64 RouterOS 7.23.3 reference router.
+
+Passed:
+
+- fresh credentialless installation;
+- generated script validation (`PASS=4 FAIL=0`);
+- adaptive TCP and UDP learning;
+- tunnel DOWN fail-open DIRECT;
+- tunnel UP recovery;
+- reboot persistence;
+- full uninstall while preserving the external VPN;
+- reinstall using the same published assets;
+- short soak with stable CPU, memory and scheduler operation;
+- no persistent Susanin script jobs observed.
+
+The previous bare `:return` / `missing value(s)` failure was not observed.
+
+Known issue:
+
+- intermittent RouterOS `no such item (4)` errors remain reproducible while the data plane is active;
+- the data plane continued operating despite these errors;
+- Issue #1 remains open for the connection-tracking investigation.
+

--- a/docs/TESTED.md
+++ b/docs/TESTED.md
@@ -1,5 +1,7 @@
 # Tested scenarios
 
+## Public pilot baseline — v0.11.3
+
 Public pilot baseline: **Susanin v0.11.3**.
 
 Reference validation was performed on ARM64 MikroTik running RouterOS 7.23.3 with an already working route-based WireGuard/AmneziaWG tunnel.
@@ -18,3 +20,67 @@ Verified:
 - tunnel unavailable during early boot caused fail-open DIRECT;
 - tunnel recovery automatically re-enabled adaptive routing;
 - controller upgrade did not require stopping the RouterOS data plane.
+
+## v0.11.4-rc1 preparation validation
+
+The v0.11.4 release candidate is being prepared from the v0.11.4 stability development branch.
+
+Already validated on the RouterOS 7.23.3 ARM64 reference system:
+
+- persistent runtime configuration in `/data/susanin.conf`;
+- configurable RouterOS log levels;
+- diagnostic recorder start/stop and bounded rotation;
+- RouterOS resource / connection-tracking / script-job telemetry;
+- `diag errors` collection from RouterOS logs;
+- RouterOS API handling that consumes the final `!done` after `!empty`;
+- replacement of unsafe bare `:return` exits with `:exit`;
+- transient address-list ID guards in the detection path;
+- FAST + DETECT operation after the address-list guard without new stale-ID errors during the test window.
+
+A clean uninstall of public v0.11.3 was also tested from a restored RouterOS configuration.
+
+Verified during uninstall:
+
+- Susanin scripts, schedulers, mangle/filter/address-list state removed;
+- Susanin controller container and mounts removed;
+- Susanin bridge, VETH and controller address removed;
+- Susanin API rule and machine user/group removed;
+- Susanin configuration and machine secret removed;
+- existing AmneziaWG container remained running;
+- existing routing table remained present;
+- existing default route through the VPN interface remained active;
+- ping through the VPN interface continued to work.
+
+The reference router was left as a clean baseline with no Susanin objects and a working external VPN.
+
+## Known RouterOS interaction under investigation
+
+RouterOS 7.23.3 can produce:
+
+~~~text
+no such item (4)
+~~~
+
+while reading the dynamic connection-tracking table.
+
+This was reproduced directly from a RouterOS terminal with Susanin schedulers disabled and Susanin mangle rules disabled while repeatedly reading `/ip firewall connection`.
+
+Therefore this error is not currently attributed exclusively to Susanin scheduler concurrency.
+
+The issue remains open. The current direction is to reduce or restructure full connection-tracking scans rather than claim the condition is solved.
+
+## Not yet verified for v0.11.4-rc1
+
+The final GitHub-built `v0.11.4-rc1` artifacts have not yet been installed on the clean reference router.
+
+Still required:
+
+- fresh install from the clean baseline;
+- first-run setup;
+- reboot;
+- tunnel DOWN fail-open;
+- tunnel UP recovery;
+- diagnostics and `diag errors`;
+- full uninstall;
+- reinstall;
+- extended soak with all four RouterOS workers enabled.

--- a/docs/TESTED.md
+++ b/docs/TESTED.md
@@ -69,18 +69,39 @@ Therefore this error is not currently attributed exclusively to Susanin schedule
 
 The issue remains open. The current direction is to reduce or restructure full connection-tracking scans rather than claim the condition is solved.
 
-## Not yet verified for v0.11.4-rc1
+## v0.11.4-rc1 field validation
 
-The final GitHub-built `v0.11.4-rc1` artifacts have not yet been installed on the clean reference router.
+The exact GitHub-generated `v0.11.4-rc1` release assets were tested on the ARM64 RouterOS 7.23.3 reference router.
 
-Still required:
+Verified:
 
-- fresh install from the clean baseline;
-- first-run setup;
-- reboot;
-- tunnel DOWN fail-open;
-- tunnel UP recovery;
-- diagnostics and `diag errors`;
-- full uninstall;
-- reinstall;
-- extended soak with all four RouterOS workers enabled.
+- credentialless bootstrap from the published `susanin.tar` and `install.rsc`;
+- controller image version `0.11.4-rc1`;
+- controller root-dir `/susanin-controller-v0114rc1`;
+- automatic detection of `wg-awg-proxy`;
+- automatic detection of routing table `r_to_awg`;
+- generated RouterOS validation `PASS=4 FAIL=0`;
+- fresh install result `scripts=4 schedulers=4 mangle=8 safety=3`;
+- existing tunnel masquerade preserved;
+- adaptive TCP and UDP learning;
+- tunnel DOWN detection and fail-open DIRECT behavior;
+- tunnel UP recovery with adaptive mangle rules restored automatically;
+- RouterOS reboot with controller and all four schedulers restored;
+- full uninstall of Susanin-owned objects;
+- external AmneziaWG container and `r_to_awg` route preserved after uninstall;
+- successful reinstall using the same GitHub release assets;
+- stable CPU and memory usage during soak testing;
+- no persistent or stuck Susanin script jobs observed.
+
+The previous bare `:return` / `missing value(s)` RouterOS script failure was not observed after changing script termination to `:exit`.
+
+### Remaining known issue
+
+`no such item (4)` remains reproducible during normal `v0.11.4-rc1` operation.
+
+After the final reinstall, RouterOS diagnostics showed this as the only script-error class observed during the test window.
+
+The data plane continued operating, learning destinations and recovering from tunnel outages despite the intermittent errors.
+
+Investigation remains tracked in GitHub Issue #1.
+

--- a/src/config.c
+++ b/src/config.c
@@ -52,6 +52,43 @@ static void trim(char *s) {
     while (n && (s[n - 1] == ' ' || s[n - 1] == '\t' || s[n - 1] == '\r' || s[n - 1] == '\n')) s[--n] = '\0';
 }
 
+static int valid_log_level(const char *value) {
+    return value &&
+        (
+            strcmp(value, "quiet") == 0 ||
+            strcmp(value, "error") == 0 ||
+            strcmp(value, "info") == 0 ||
+            strcmp(value, "debug") == 0 ||
+            strcmp(value, "trace") == 0
+        );
+}
+
+static int parse_unsigned_range(
+    const char *value,
+    unsigned min,
+    unsigned max,
+    unsigned *out
+) {
+    if (!value || !*value || !out) return -1;
+
+    errno = 0;
+    char *end = NULL;
+    unsigned long n = strtoul(value, &end, 10);
+
+    if (
+        errno ||
+        !end ||
+        *end ||
+        n < min ||
+        n > max
+    ) {
+        return -1;
+    }
+
+    *out = (unsigned)n;
+    return 0;
+}
+
 static void load_nonsecret_config(app_config_t *cfg) {
     snprintf(cfg->lan_buf, sizeof(cfg->lan_buf), "LAN");
     FILE *f = fopen(SUSANIN_CONFIG_FILE, "r");
@@ -67,56 +104,413 @@ static void load_nonsecret_config(app_config_t *cfg) {
         if (strcmp(line, "lan_list") == 0 && *eq) snprintf(cfg->lan_buf, sizeof(cfg->lan_buf), "%s", eq);
         else if (strcmp(line, "egress_interface") == 0 && *eq) snprintf(cfg->egress_buf, sizeof(cfg->egress_buf), "%s", eq);
         else if (strcmp(line, "routing_table") == 0 && *eq) snprintf(cfg->table_buf, sizeof(cfg->table_buf), "%s", eq);
-        else if (strcmp(line, "router_host") == 0 && *eq) snprintf(cfg->host_buf, sizeof(cfg->host_buf), "%s", eq);
+        else if (strcmp(line, "router_host") == 0 && *eq) {
+            snprintf(
+                cfg->host_buf,
+                sizeof(cfg->host_buf),
+                "%s",
+                eq
+            );
+            cfg->host_configured = 1;
+        }
         else if (strcmp(line, "router_port") == 0 && *eq) {
             errno = 0; char *end = NULL; long p = strtol(eq, &end, 10);
-            if (!errno && end && !*end && p >= 1 && p <= 65535) cfg->port = (uint16_t)p;
+            if (!errno && end && !*end && p >= 1 && p <= 65535) {
+                cfg->port = (uint16_t)p;
+                cfg->port_configured = 1;
+            }
+        }
+        else if (
+            strcmp(line, "log_level") == 0 &&
+            valid_log_level(eq)
+        ) {
+            snprintf(
+                cfg->log_level_buf,
+                sizeof(cfg->log_level_buf),
+                "%s",
+                eq
+            );
+        }
+        else if (strcmp(line, "diagnostics") == 0) {
+            if (strcmp(eq, "on") == 0) {
+                cfg->diagnostics_enabled = 1;
+            } else if (strcmp(eq, "off") == 0) {
+                cfg->diagnostics_enabled = 0;
+            }
+        }
+        else if (
+            strcmp(line, "diagnostic_max_size_mb") == 0
+        ) {
+            unsigned value = 0;
+
+            if (
+                parse_unsigned_range(
+                    eq,
+                    1,
+                    100,
+                    &value
+                ) == 0
+            ) {
+                cfg->diagnostic_max_size_mb = value;
+            }
+        }
+        else if (
+            strcmp(line, "diagnostic_max_files") == 0
+        ) {
+            unsigned value = 0;
+
+            if (
+                parse_unsigned_range(
+                    eq,
+                    1,
+                    10,
+                    &value
+                ) == 0
+            ) {
+                cfg->diagnostic_max_files = value;
+            }
         }
     }
     fclose(f);
 }
 
-int config_load(app_config_t *cfg) {
+int config_load_local(app_config_t *cfg) {
     if (!cfg) return -1;
+
     memset(cfg, 0, sizeof(*cfg));
     cfg->port = 8728;
+
+    snprintf(
+        cfg->log_level_buf,
+        sizeof(cfg->log_level_buf),
+        "info"
+    );
+
+    cfg->diagnostics_enabled = 0;
+    cfg->diagnostic_max_size_mb = 10;
+    cfg->diagnostic_max_files = 3;
+
     load_nonsecret_config(cfg);
 
-    if (!cfg->host_buf[0] && infer_default_gateway(cfg->host_buf) < 0) {
-        snprintf(cfg->host_buf, sizeof(cfg->host_buf), "172.31.254.1");
-    }
-    if (read_text_file(SUSANIN_SECRET_PASSWORD, cfg->password_buf, sizeof(cfg->password_buf)) < 0) {
-        fprintf(stderr, "Susanin bootstrap secret is missing: %s\n", SUSANIN_SECRET_PASSWORD);
-        fprintf(stderr, "Install Susanin with the RouterOS bootstrap script; no user-entered credentials are required.\n");
-        return -1;
+    if (
+        !cfg->host_buf[0] &&
+        infer_default_gateway(cfg->host_buf) < 0
+    ) {
+        snprintf(
+            cfg->host_buf,
+            sizeof(cfg->host_buf),
+            "172.31.254.1"
+        );
     }
 
     cfg->host = cfg->host_buf;
     cfg->user = SUSANIN_AGENT_USER;
+    cfg->password = NULL;
+
+    cfg->lan_list =
+        cfg->lan_buf[0]
+            ? cfg->lan_buf
+            : "LAN";
+
+    cfg->egress_interface =
+        cfg->egress_buf[0]
+            ? cfg->egress_buf
+            : NULL;
+
+    cfg->routing_table =
+        cfg->table_buf[0]
+            ? cfg->table_buf
+            : NULL;
+
+    cfg->log_level = cfg->log_level_buf;
+
+    cfg->selection_configured =
+        cfg->egress_interface &&
+        cfg->routing_table;
+
+    return 0;
+}
+
+int config_load(app_config_t *cfg) {
+    if (config_load_local(cfg) < 0) {
+        return -1;
+    }
+
+    if (
+        read_text_file(
+            SUSANIN_SECRET_PASSWORD,
+            cfg->password_buf,
+            sizeof(cfg->password_buf)
+        ) < 0
+    ) {
+        fprintf(
+            stderr,
+            "Susanin bootstrap secret is missing: %s\n",
+            SUSANIN_SECRET_PASSWORD
+        );
+
+        fprintf(
+            stderr,
+            "Install Susanin with the RouterOS bootstrap script; "
+            "no user-entered credentials are required.\n"
+        );
+
+        return -1;
+    }
+
     cfg->password = cfg->password_buf;
-    cfg->lan_list = cfg->lan_buf[0] ? cfg->lan_buf : "LAN";
-    cfg->egress_interface = cfg->egress_buf[0] ? cfg->egress_buf : NULL;
-    cfg->routing_table = cfg->table_buf[0] ? cfg->table_buf : NULL;
-    cfg->selection_configured = cfg->egress_interface && cfg->routing_table;
+
+    return 0;
+}
+
+static int write_nonsecret_config(const app_config_t *cfg) {
+    if (!cfg) return -1;
+
+    FILE *f = fopen(SUSANIN_CONFIG_FILE ".tmp", "w");
+    if (!f) {
+        perror("open Susanin config");
+        return -1;
+    }
+
+    fprintf(
+        f,
+        "# Susanin non-secret runtime configuration\n"
+    );
+
+    fprintf(
+        f,
+        "lan_list=%s\n",
+        cfg->lan_list ? cfg->lan_list : "LAN"
+    );
+
+    if (
+        cfg->egress_interface &&
+        *cfg->egress_interface
+    ) {
+        fprintf(
+            f,
+            "egress_interface=%s\n",
+            cfg->egress_interface
+        );
+    }
+
+    if (
+        cfg->routing_table &&
+        *cfg->routing_table
+    ) {
+        fprintf(
+            f,
+            "routing_table=%s\n",
+            cfg->routing_table
+        );
+    }
+
+    if (
+        cfg->host_configured &&
+        cfg->host &&
+        *cfg->host
+    ) {
+        fprintf(
+            f,
+            "router_host=%s\n",
+            cfg->host
+        );
+    }
+
+    if (cfg->port_configured) {
+        fprintf(
+            f,
+            "router_port=%u\n",
+            (unsigned)cfg->port
+        );
+    }
+
+    fprintf(
+        f,
+        "log_level=%s\n",
+        cfg->log_level ? cfg->log_level : "info"
+    );
+
+    fprintf(
+        f,
+        "diagnostics=%s\n",
+        cfg->diagnostics_enabled ? "on" : "off"
+    );
+
+    fprintf(
+        f,
+        "diagnostic_max_size_mb=%u\n",
+        cfg->diagnostic_max_size_mb
+    );
+
+    fprintf(
+        f,
+        "diagnostic_max_files=%u\n",
+        cfg->diagnostic_max_files
+    );
+
+    if (fclose(f) != 0) {
+        perror("close Susanin config");
+        remove(SUSANIN_CONFIG_FILE ".tmp");
+        return -1;
+    }
+
+    if (
+        rename(
+            SUSANIN_CONFIG_FILE ".tmp",
+            SUSANIN_CONFIG_FILE
+        ) != 0
+    ) {
+        perror("rename Susanin config");
+        remove(SUSANIN_CONFIG_FILE ".tmp");
+        return -1;
+    }
+
     return 0;
 }
 
 int config_save_selection(app_config_t *cfg, const char *egress, const char *table) {
     if (!cfg || !egress || !*egress || !table || !*table) return -1;
-    FILE *f = fopen(SUSANIN_CONFIG_FILE ".tmp", "w");
-    if (!f) { perror("open Susanin config"); return -1; }
-    fprintf(f, "# Susanin non-secret runtime selection\n");
-    fprintf(f, "lan_list=%s\n", cfg->lan_list ? cfg->lan_list : "LAN");
-    fprintf(f, "egress_interface=%s\n", egress);
-    fprintf(f, "routing_table=%s\n", table);
-    if (fclose(f) != 0) return -1;
-    if (rename(SUSANIN_CONFIG_FILE ".tmp", SUSANIN_CONFIG_FILE) != 0) { perror("rename Susanin config"); return -1; }
-    snprintf(cfg->egress_buf, sizeof(cfg->egress_buf), "%s", egress);
-    snprintf(cfg->table_buf, sizeof(cfg->table_buf), "%s", table);
+
+    snprintf(
+        cfg->egress_buf,
+        sizeof(cfg->egress_buf),
+        "%s",
+        egress
+    );
+
+    snprintf(
+        cfg->table_buf,
+        sizeof(cfg->table_buf),
+        "%s",
+        table
+    );
+
     cfg->egress_interface = cfg->egress_buf;
     cfg->routing_table = cfg->table_buf;
     cfg->selection_configured = 1;
-    return 0;
+
+    return write_nonsecret_config(cfg);
+}
+
+int config_set_option(
+    app_config_t *cfg,
+    const char *key,
+    const char *value
+) {
+    if (!cfg || !key || !value) return -1;
+
+    if (strcmp(key, "log-level") == 0) {
+        if (!valid_log_level(value)) {
+            fprintf(
+                stderr,
+                "Invalid log level. Use: quiet, error, info, debug, trace\n"
+            );
+            return -1;
+        }
+
+        snprintf(
+            cfg->log_level_buf,
+            sizeof(cfg->log_level_buf),
+            "%s",
+            value
+        );
+        cfg->log_level = cfg->log_level_buf;
+
+    } else if (strcmp(key, "diagnostics") == 0) {
+
+        if (strcmp(value, "on") == 0) {
+            cfg->diagnostics_enabled = 1;
+        } else if (strcmp(value, "off") == 0) {
+            cfg->diagnostics_enabled = 0;
+        } else {
+            fprintf(
+                stderr,
+                "Invalid diagnostics value. Use: on or off\n"
+            );
+            return -1;
+        }
+
+    } else if (
+        strcmp(key, "diagnostic-max-size-mb") == 0
+    ) {
+        unsigned n = 0;
+
+        if (
+            parse_unsigned_range(
+                value,
+                1,
+                100,
+                &n
+            ) < 0
+        ) {
+            fprintf(
+                stderr,
+                "Invalid diagnostic-max-size-mb. Use: 1..100\n"
+            );
+            return -1;
+        }
+
+        cfg->diagnostic_max_size_mb = n;
+
+    } else if (
+        strcmp(key, "diagnostic-max-files") == 0
+    ) {
+        unsigned n = 0;
+
+        if (
+            parse_unsigned_range(
+                value,
+                1,
+                10,
+                &n
+            ) < 0
+        ) {
+            fprintf(
+                stderr,
+                "Invalid diagnostic-max-files. Use: 1..10\n"
+            );
+            return -1;
+        }
+
+        cfg->diagnostic_max_files = n;
+
+    } else {
+        fprintf(
+            stderr,
+            "Unknown config key: %s\n",
+            key
+        );
+        return -1;
+    }
+
+    return write_nonsecret_config(cfg);
+}
+
+void config_print_settings(const app_config_t *cfg) {
+    if (!cfg) return;
+
+    printf("=== SUSANIN SETTINGS ===\n\n");
+
+    printf(
+        "Logging level        : %s\n",
+        cfg->log_level ? cfg->log_level : "info"
+    );
+
+    printf(
+        "Diagnostic recorder  : %s\n",
+        cfg->diagnostics_enabled ? "on" : "off"
+    );
+
+    printf(
+        "Diagnostic max size  : %u MB\n",
+        cfg->diagnostic_max_size_mb
+    );
+
+    printf(
+        "Diagnostic max files : %u\n",
+        cfg->diagnostic_max_files
+    );
 }
 
 void config_print_safe(const app_config_t *cfg) {

--- a/src/config.h
+++ b/src/config.h
@@ -12,16 +12,29 @@ typedef struct {
     const char *lan_list;
     const char *egress_interface;
     const char *routing_table;
+    const char *log_level;
+
     char host_buf[256];
     char password_buf[1024];
     char lan_buf[128];
     char egress_buf[128];
     char table_buf[128];
+    char log_level_buf[16];
+
+    unsigned diagnostic_max_size_mb;
+    unsigned diagnostic_max_files;
+
+    int diagnostics_enabled;
+    int host_configured;
+    int port_configured;
     int selection_configured;
 } app_config_t;
 
+int config_load_local(app_config_t *cfg);
 int config_load(app_config_t *cfg);
 int config_save_selection(app_config_t *cfg, const char *egress, const char *table);
+int config_set_option(app_config_t *cfg, const char *key, const char *value);
 void config_print_safe(const app_config_t *cfg);
+void config_print_settings(const app_config_t *cfg);
 
 #endif

--- a/src/diag.c
+++ b/src/diag.c
@@ -1,0 +1,375 @@
+#include "diag.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <time.h>
+
+#define DIAG_DIR "/data/diagnostics"
+#define DIAG_FILE DIAG_DIR "/susanin-debug.ndjson"
+
+static int ensure_directory(const char *path) {
+    if (mkdir(path, 0750) == 0) return 0;
+    if (errno == EEXIST) return 0;
+
+    perror(path);
+    return -1;
+}
+
+static int ensure_diag_directory(void) {
+    if (ensure_directory("/data") < 0) return -1;
+    if (ensure_directory(DIAG_DIR) < 0) return -1;
+    return 0;
+}
+
+static void rotated_path(
+    unsigned index,
+    char *out,
+    size_t out_size
+) {
+    if (index == 0) {
+        snprintf(out, out_size, "%s", DIAG_FILE);
+    } else {
+        snprintf(
+            out,
+            out_size,
+            "%s.%u",
+            DIAG_FILE,
+            index
+        );
+    }
+}
+
+static int rotate_if_needed(
+    const app_config_t *cfg
+) {
+    struct stat st;
+
+    if (stat(DIAG_FILE, &st) != 0) {
+        if (errno == ENOENT) return 0;
+
+        perror("stat diagnostic log");
+        return -1;
+    }
+
+    unsigned long long limit =
+        (unsigned long long)cfg->diagnostic_max_size_mb *
+        1024ULL *
+        1024ULL;
+
+    if ((unsigned long long)st.st_size < limit) {
+        return 0;
+    }
+
+    unsigned max_files = cfg->diagnostic_max_files;
+
+    if (max_files < 1) max_files = 1;
+
+    if (max_files == 1) {
+        if (remove(DIAG_FILE) != 0 && errno != ENOENT) {
+            perror("remove diagnostic log");
+            return -1;
+        }
+
+        return 0;
+    }
+
+    for (
+        unsigned i = max_files - 1;
+        i > 0;
+        --i
+    ) {
+        char src[512];
+        char dst[512];
+
+        rotated_path(i - 1, src, sizeof(src));
+        rotated_path(i, dst, sizeof(dst));
+
+        if (i == max_files - 1) {
+            if (remove(dst) != 0 && errno != ENOENT) {
+                perror("remove old diagnostic log");
+                return -1;
+            }
+        }
+
+        if (rename(src, dst) != 0) {
+            if (errno != ENOENT) {
+                perror("rotate diagnostic log");
+                return -1;
+            }
+        }
+    }
+
+    return 0;
+}
+
+static void json_string(
+    FILE *f,
+    const char *s
+) {
+    fputc('"', f);
+
+    if (s) {
+        const unsigned char *p =
+            (const unsigned char *)s;
+
+        while (*p) {
+            unsigned char c = *p++;
+
+            switch (c) {
+                case '"':
+                    fputs("\\\"", f);
+                    break;
+
+                case '\\':
+                    fputs("\\\\", f);
+                    break;
+
+                case '\n':
+                    fputs("\\n", f);
+                    break;
+
+                case '\r':
+                    fputs("\\r", f);
+                    break;
+
+                case '\t':
+                    fputs("\\t", f);
+                    break;
+
+                default:
+                    if (c < 0x20) {
+                        fprintf(
+                            f,
+                            "\\u%04x",
+                            (unsigned)c
+                        );
+                    } else {
+                        fputc((int)c, f);
+                    }
+                    break;
+            }
+        }
+    }
+
+    fputc('"', f);
+}
+
+static void timestamp_utc(
+    char out[32]
+) {
+    time_t now = time(NULL);
+    struct tm *tm_now = gmtime(&now);
+
+    if (!tm_now) {
+        snprintf(
+            out,
+            32,
+            "1970-01-01T00:00:00Z"
+        );
+        return;
+    }
+
+    if (
+        strftime(
+            out,
+            32,
+            "%Y-%m-%dT%H:%M:%SZ",
+            tm_now
+        ) == 0
+    ) {
+        snprintf(
+            out,
+            32,
+            "1970-01-01T00:00:00Z"
+        );
+    }
+}
+
+int diag_event(
+    const app_config_t *cfg,
+    const char *type,
+    const char *message
+) {
+    if (!cfg || !cfg->diagnostics_enabled) {
+        return 0;
+    }
+
+    if (ensure_diag_directory() < 0) {
+        return -1;
+    }
+
+    if (rotate_if_needed(cfg) < 0) {
+        return -1;
+    }
+
+    FILE *f = fopen(DIAG_FILE, "a");
+
+    if (!f) {
+        perror("open diagnostic log");
+        return -1;
+    }
+
+    char ts[32];
+    timestamp_utc(ts);
+
+    fputs("{\"ts\":", f);
+    json_string(f, ts);
+
+    fputs(",\"type\":", f);
+    json_string(f, type ? type : "event");
+
+    fputs(",\"message\":", f);
+    json_string(f, message ? message : "");
+
+    fputs("}\n", f);
+
+    if (fclose(f) != 0) {
+        perror("close diagnostic log");
+        return -1;
+    }
+
+    return 0;
+}
+
+int diag_start(app_config_t *cfg) {
+    if (!cfg) return -1;
+
+    if (ensure_diag_directory() < 0) {
+        return -1;
+    }
+
+    if (cfg->diagnostics_enabled) {
+        printf(
+            "Diagnostic recorder is already enabled.\n"
+        );
+        return 0;
+    }
+
+    if (
+        config_set_option(
+            cfg,
+            "diagnostics",
+            "on"
+        ) < 0
+    ) {
+        return -1;
+    }
+
+    if (
+        diag_event(
+            cfg,
+            "session_start",
+            "Diagnostic recorder enabled"
+        ) < 0
+    ) {
+        (void)config_set_option(
+            cfg,
+            "diagnostics",
+            "off"
+        );
+
+        return -1;
+    }
+
+    printf(
+        "Diagnostic recorder enabled.\n"
+        "Output: %s\n",
+        DIAG_FILE
+    );
+
+    return 0;
+}
+
+int diag_stop(app_config_t *cfg) {
+    if (!cfg) return -1;
+
+    if (!cfg->diagnostics_enabled) {
+        printf(
+            "Diagnostic recorder is already disabled.\n"
+        );
+        return 0;
+    }
+
+    int event_rc = diag_event(
+        cfg,
+        "session_stop",
+        "Diagnostic recorder disabled"
+    );
+
+    if (
+        config_set_option(
+            cfg,
+            "diagnostics",
+            "off"
+        ) < 0
+    ) {
+        return -1;
+    }
+
+    if (event_rc < 0) {
+        fprintf(
+            stderr,
+            "Warning: diagnostic recorder was disabled, "
+            "but the final event could not be written.\n"
+        );
+    }
+
+    printf("Diagnostic recorder disabled.\n");
+
+    return event_rc < 0 ? -1 : 0;
+}
+
+int diag_status(const app_config_t *cfg) {
+    if (!cfg) return -1;
+
+    printf("=== SUSANIN DIAGNOSTICS ===\n\n");
+
+    printf(
+        "Recorder : %s\n",
+        cfg->diagnostics_enabled
+            ? "on"
+            : "off"
+    );
+
+    printf(
+        "File     : %s\n",
+        DIAG_FILE
+    );
+
+    printf(
+        "Max size : %u MB\n",
+        cfg->diagnostic_max_size_mb
+    );
+
+    printf(
+        "Max files: %u\n",
+        cfg->diagnostic_max_files
+    );
+
+    unsigned files = 0;
+    unsigned long long total = 0;
+
+    for (
+        unsigned i = 0;
+        i < cfg->diagnostic_max_files;
+        ++i
+    ) {
+        char path[512];
+        struct stat st;
+
+        rotated_path(i, path, sizeof(path));
+
+        if (stat(path, &st) == 0) {
+            ++files;
+            total +=
+                (unsigned long long)st.st_size;
+        }
+    }
+
+    printf("Stored   : %u file(s)\n", files);
+    printf("Bytes    : %llu\n", total);
+
+    return 0;
+}

--- a/src/diag.h
+++ b/src/diag.h
@@ -1,0 +1,16 @@
+#ifndef SUSANIN_DIAG_H
+#define SUSANIN_DIAG_H
+
+#include "config.h"
+
+int diag_start(app_config_t *cfg);
+int diag_stop(app_config_t *cfg);
+int diag_status(const app_config_t *cfg);
+
+int diag_event(
+    const app_config_t *cfg,
+    const char *type,
+    const char *message
+);
+
+#endif

--- a/src/install.c
+++ b/src/install.c
@@ -3,6 +3,7 @@
 #include "fingerprint.h"
 #include "renderer.h"
 #include "validate.h"
+#include "version.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -161,7 +162,7 @@ static int add_script(ros_client_t *ros, const susanin_rendered_script_t *s) {
     size_t n1 = strlen(s->name) + 7;
     size_t n2 = strlen(s->source) + 9;
     char comment[192];
-    snprintf(comment, sizeof(comment), "SUSANIN:v0.11.3 managed source fp=%s", s->fp);
+    snprintf(comment, sizeof(comment), "SUSANIN:v" SUSANIN_VERSION " managed source fp=%s", s->fp);
     size_t n3 = strlen(comment) + 10;
     char *wname = malloc(n1), *wsource = malloc(n2), *wcomment = malloc(n3);
     if (!wname || !wsource || !wcomment) {
@@ -353,7 +354,7 @@ int install_run(ros_client_t *ros, const app_config_t *cfg, int dry_run) {
         return -1;
     }
     if (dry_run) {
-        printf("=== SUSANIN FRESH INSTALL DRY-RUN v0.11.3 ===\n");
+        printf("=== SUSANIN FRESH INSTALL DRY-RUN v%s ===\n", SUSANIN_VERSION);
         printf("RouterOS changes: NONE\n");
         printf("Managed legacy-compatible objects present: %u/16\n", present);
         printf("Susanin fresh-install support objects present: %u/4\n", support);
@@ -381,7 +382,7 @@ int install_run(ros_client_t *ros, const app_config_t *cfg, int dry_run) {
         return 0;
     }
 
-    printf("=== SUSANIN FRESH INSTALL v0.11.3 ===\n");
+    printf("=== SUSANIN FRESH INSTALL v%s ===\n", SUSANIN_VERSION);
     if (present == 16) {
         printf("Existing complete installation detected. Data-plane changes: NONE.\n");
         return 0;

--- a/src/main.c
+++ b/src/main.c
@@ -2,6 +2,7 @@
 #include "config.h"
 #include "diag.h"
 #include "telemetry.h"
+#include "routerlog.h"
 #include "discovery.h"
 #include "routeros_api.h"
 #include "status.h"
@@ -55,7 +56,9 @@ static void usage(const char *argv0) {
         "  %s diag status\n"
         "  %s diag start\n"
         "  %s diag stop\n"
-        "  %s diag sample\n",
+        "  %s diag sample\n"
+        "  %s diag errors\n",
+        argv0,
         argv0,
         argv0,
         argv0,
@@ -92,6 +95,7 @@ int main(int argc, char **argv) {
     int diag_start_cmd = 0;
     int diag_stop_cmd = 0;
     int diag_sample_cmd = 0;
+    int diag_errors_cmd = 0;
 
     if (argc == 2 && strcmp(argv[1], "discover") == 0) {
         /* read-only */
@@ -159,6 +163,12 @@ int main(int argc, char **argv) {
         strcmp(argv[2], "sample") == 0
     ) {
         diag_sample_cmd = 1;
+    } else if (
+        argc == 3 &&
+        strcmp(argv[1], "diag") == 0 &&
+        strcmp(argv[2], "errors") == 0
+    ) {
+        diag_errors_cmd = 1;
     } else if (argc == 2 && strcmp(argv[1], "daemon") == 0) {
         daemon = 1;
     } else if (argc == 2 && strcmp(argv[1], "apply") == 0) {
@@ -299,7 +309,8 @@ int main(int argc, char **argv) {
 
     printf("Authenticated.\n\n");
     int rc;
-    if (diag_sample_cmd) rc = telemetry_collect_once(&ros, &cfg);
+    if (diag_errors_cmd) rc = routerlog_collect_errors(&ros, &cfg);
+    else if (diag_sample_cmd) rc = telemetry_collect_once(&ros, &cfg);
     else if (setup) rc = setup_run(&ros, &cfg);
     else if (install_dry) rc = install_run(&ros, &cfg, 1);
     else if (install) rc = install_run(&ros, &cfg, 0);

--- a/src/main.c
+++ b/src/main.c
@@ -1,5 +1,6 @@
 #include "apply.h"
 #include "config.h"
+#include "diag.h"
 #include "discovery.h"
 #include "routeros_api.h"
 #include "status.h"
@@ -45,6 +46,20 @@ static void usage(const char *argv0) {
         "  - VPN selection is stored in /data/susanin.conf.\n"
         "  - No environment file is used.\n",
         SUSANIN_VERSION, argv0, argv0, argv0, argv0, argv0, argv0, argv0, argv0, argv0, argv0, argv0, argv0, argv0, argv0, argv0, argv0, argv0);
+    fprintf(
+        stderr,
+        "\nLocal settings and diagnostics:\n"
+        "  %s config show\n"
+        "  %s config set <key> <value>\n"
+        "  %s diag status\n"
+        "  %s diag start\n"
+        "  %s diag stop\n",
+        argv0,
+        argv0,
+        argv0,
+        argv0,
+        argv0
+    );
 }
 
 int main(int argc, char **argv) {
@@ -70,6 +85,9 @@ int main(int argc, char **argv) {
     int daemon = 0;
     int config_show = 0;
     int config_set = 0;
+    int diag_status_cmd = 0;
+    int diag_start_cmd = 0;
+    int diag_stop_cmd = 0;
 
     if (argc == 2 && strcmp(argv[1], "discover") == 0) {
         /* read-only */
@@ -113,6 +131,24 @@ int main(int argc, char **argv) {
         strcmp(argv[2], "set") == 0
     ) {
         config_set = 1;
+    } else if (
+        argc == 3 &&
+        strcmp(argv[1], "diag") == 0 &&
+        strcmp(argv[2], "status") == 0
+    ) {
+        diag_status_cmd = 1;
+    } else if (
+        argc == 3 &&
+        strcmp(argv[1], "diag") == 0 &&
+        strcmp(argv[2], "start") == 0
+    ) {
+        diag_start_cmd = 1;
+    } else if (
+        argc == 3 &&
+        strcmp(argv[1], "diag") == 0 &&
+        strcmp(argv[2], "stop") == 0
+    ) {
+        diag_stop_cmd = 1;
     } else if (argc == 2 && strcmp(argv[1], "daemon") == 0) {
         daemon = 1;
     } else if (argc == 2 && strcmp(argv[1], "apply") == 0) {
@@ -131,7 +167,13 @@ int main(int argc, char **argv) {
 
     app_config_t cfg;
 
-    if (config_show || config_set) {
+    if (
+        config_show ||
+        config_set ||
+        diag_status_cmd ||
+        diag_start_cmd ||
+        diag_stop_cmd
+    ) {
         if (config_load_local(&cfg) < 0) {
             return 2;
         }
@@ -141,19 +183,33 @@ int main(int argc, char **argv) {
             return 0;
         }
 
-        if (
-            config_set_option(
-                &cfg,
-                argv[3],
-                argv[4]
-            ) < 0
-        ) {
-            return 2;
+        if (config_set) {
+            if (
+                config_set_option(
+                    &cfg,
+                    argv[3],
+                    argv[4]
+                ) < 0
+            ) {
+                return 2;
+            }
+
+            printf("Susanin setting saved.\n\n");
+            config_print_settings(&cfg);
+            return 0;
         }
 
-        printf("Susanin setting saved.\n\n");
-        config_print_settings(&cfg);
-        return 0;
+        if (diag_status_cmd) {
+            return diag_status(&cfg) == 0 ? 0 : 1;
+        }
+
+        if (diag_start_cmd) {
+            return diag_start(&cfg) == 0 ? 0 : 1;
+        }
+
+        if (diag_stop_cmd) {
+            return diag_stop(&cfg) == 0 ? 0 : 1;
+        }
     }
 
     if (config_load(&cfg) < 0) return 2;

--- a/src/main.c
+++ b/src/main.c
@@ -1,6 +1,7 @@
 #include "apply.h"
 #include "config.h"
 #include "diag.h"
+#include "telemetry.h"
 #include "discovery.h"
 #include "routeros_api.h"
 #include "status.h"
@@ -53,7 +54,9 @@ static void usage(const char *argv0) {
         "  %s config set <key> <value>\n"
         "  %s diag status\n"
         "  %s diag start\n"
-        "  %s diag stop\n",
+        "  %s diag stop\n"
+        "  %s diag sample\n",
+        argv0,
         argv0,
         argv0,
         argv0,
@@ -88,6 +91,7 @@ int main(int argc, char **argv) {
     int diag_status_cmd = 0;
     int diag_start_cmd = 0;
     int diag_stop_cmd = 0;
+    int diag_sample_cmd = 0;
 
     if (argc == 2 && strcmp(argv[1], "discover") == 0) {
         /* read-only */
@@ -149,6 +153,12 @@ int main(int argc, char **argv) {
         strcmp(argv[2], "stop") == 0
     ) {
         diag_stop_cmd = 1;
+    } else if (
+        argc == 3 &&
+        strcmp(argv[1], "diag") == 0 &&
+        strcmp(argv[2], "sample") == 0
+    ) {
+        diag_sample_cmd = 1;
     } else if (argc == 2 && strcmp(argv[1], "daemon") == 0) {
         daemon = 1;
     } else if (argc == 2 && strcmp(argv[1], "apply") == 0) {
@@ -289,7 +299,8 @@ int main(int argc, char **argv) {
 
     printf("Authenticated.\n\n");
     int rc;
-    if (setup) rc = setup_run(&ros, &cfg);
+    if (diag_sample_cmd) rc = telemetry_collect_once(&ros, &cfg);
+    else if (setup) rc = setup_run(&ros, &cfg);
     else if (install_dry) rc = install_run(&ros, &cfg, 1);
     else if (install) rc = install_run(&ros, &cfg, 0);
     else if (apply_dry) rc = apply_dry_run(&ros, &cfg);

--- a/src/main.c
+++ b/src/main.c
@@ -13,12 +13,11 @@
 #include "promote.h"
 #include "setup.h"
 #include "install.h"
+#include "version.h"
 
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>
-
-#define SUSANIN_VERSION "0.11.4-dev"
 
 static void usage(const char *argv0) {
     fprintf(stderr,

--- a/src/main.c
+++ b/src/main.c
@@ -160,8 +160,19 @@ int main(int argc, char **argv) {
     }
 
     if (daemon) {
+        app_config_t daemon_cfg;
+
+        if (config_load_local(&daemon_cfg) == 0) {
+            (void)diag_event(
+                &daemon_cfg,
+                "controller_start",
+                "Susanin controller daemon started"
+            );
+        }
+
         printf("Susanin controller is running. Use RouterOS /container/shell with `susanin setup` for first-run setup.\n");
         fflush(stdout);
+
         for (;;) sleep(3600);
     }
 
@@ -194,6 +205,24 @@ int main(int argc, char **argv) {
                 return 2;
             }
 
+            if (cfg.diagnostics_enabled) {
+                char event_message[256];
+
+                snprintf(
+                    event_message,
+                    sizeof(event_message),
+                    "%s=%s",
+                    argv[3],
+                    argv[4]
+                );
+
+                (void)diag_event(
+                    &cfg,
+                    "config_change",
+                    event_message
+                );
+            }
+
             printf("Susanin setting saved.\n\n");
             config_print_settings(&cfg);
             return 0;
@@ -214,19 +243,49 @@ int main(int argc, char **argv) {
 
     if (config_load(&cfg) < 0) return 2;
 
+    (void)diag_event(
+        &cfg,
+        "command_start",
+        argv[1]
+    );
+
     config_print_safe(&cfg);
     printf("\nConnecting...\n");
 
     ros_client_t ros;
     if (ros_connect(&ros, cfg.host, cfg.port) < 0) {
+        (void)diag_event(
+            &cfg,
+            "routeros_error",
+            "RouterOS API connection failed"
+        );
+
         fprintf(stderr, "Cannot connect to RouterOS API at %s:%u\n", cfg.host, (unsigned)cfg.port);
         return 1;
     }
+
+    (void)diag_event(
+        &cfg,
+        "routeros_connected",
+        "RouterOS API connection established"
+    );
     if (ros_login(&ros, cfg.user, cfg.password) < 0) {
+        (void)diag_event(
+            &cfg,
+            "routeros_error",
+            "RouterOS API authentication failed"
+        );
+
         fprintf(stderr, "RouterOS API login failed\n");
         ros_close(&ros);
         return 1;
     }
+
+    (void)diag_event(
+        &cfg,
+        "routeros_authenticated",
+        "RouterOS API authentication succeeded"
+    );
 
     printf("Authenticated.\n\n");
     int rc;
@@ -246,5 +305,24 @@ int main(int argc, char **argv) {
     else rc = discovery_run(&ros, &cfg, plan);
 
     ros_close(&ros);
+
+    {
+        char event_message[256];
+
+        snprintf(
+            event_message,
+            sizeof(event_message),
+            "%s rc=%d",
+            argv[1],
+            rc
+        );
+
+        (void)diag_event(
+            &cfg,
+            "command_finish",
+            event_message
+        );
+    }
+
     return rc == 0 ? 0 : 1;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -15,7 +15,7 @@
 #include <string.h>
 #include <unistd.h>
 
-#define SUSANIN_VERSION "0.11.3"
+#define SUSANIN_VERSION "0.11.4-dev"
 
 static void usage(const char *argv0) {
     fprintf(stderr,
@@ -68,6 +68,8 @@ int main(int argc, char **argv) {
     int install_dry = 0;
     int install = 0;
     int daemon = 0;
+    int config_show = 0;
+    int config_set = 0;
 
     if (argc == 2 && strcmp(argv[1], "discover") == 0) {
         /* read-only */
@@ -99,6 +101,18 @@ int main(int argc, char **argv) {
         install_dry = 1;
     } else if (argc == 2 && strcmp(argv[1], "install") == 0) {
         install = 1;
+    } else if (
+        argc == 3 &&
+        strcmp(argv[1], "config") == 0 &&
+        strcmp(argv[2], "show") == 0
+    ) {
+        config_show = 1;
+    } else if (
+        argc == 5 &&
+        strcmp(argv[1], "config") == 0 &&
+        strcmp(argv[2], "set") == 0
+    ) {
+        config_set = 1;
     } else if (argc == 2 && strcmp(argv[1], "daemon") == 0) {
         daemon = 1;
     } else if (argc == 2 && strcmp(argv[1], "apply") == 0) {
@@ -116,6 +130,32 @@ int main(int argc, char **argv) {
     }
 
     app_config_t cfg;
+
+    if (config_show || config_set) {
+        if (config_load_local(&cfg) < 0) {
+            return 2;
+        }
+
+        if (config_show) {
+            config_print_settings(&cfg);
+            return 0;
+        }
+
+        if (
+            config_set_option(
+                &cfg,
+                argv[3],
+                argv[4]
+            ) < 0
+        ) {
+            return 2;
+        }
+
+        printf("Susanin setting saved.\n\n");
+        config_print_settings(&cfg);
+        return 0;
+    }
+
     if (config_load(&cfg) < 0) return 2;
 
     config_print_safe(&cfg);

--- a/src/promote.c
+++ b/src/promote.c
@@ -2,6 +2,7 @@
 #include "promote.h"
 #include "fingerprint.h"
 #include "renderer.h"
+#include "version.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -275,7 +276,7 @@ static int create_backups(ros_client_t *ros, script_obj_t prod[MANAGED_COUNT]) {
         if (remove_script_name(ros, backup_names[i]) < 0) return -1;
         char comment[192];
         snprintf(comment, sizeof(comment),
-                 "SUSANIN:v0.11.3 rollback backup of %s fp=%s; DO NOT RUN",
+                 "SUSANIN:v" SUSANIN_VERSION " rollback backup of %s fp=%s; DO NOT RUN",
                  prod_names[i], prod[i].fp);
         if (add_inert_script(ros, backup_names[i], prod[i].source, comment) < 0) return -1;
         if (verify_source(ros, backup_names[i], prod[i].fp, prod[i].bytes) < 0) return -1;
@@ -297,7 +298,7 @@ static int restore_sources(ros_client_t *ros, script_obj_t prod[MANAGED_COUNT]) 
 int promote_dry_run(ros_client_t *ros, const app_config_t *cfg) {
     susanin_render_bundle_t desired;
     if (renderer_build(ros, cfg, &desired) < 0) return -1;
-    printf("=== SUSANIN PROMOTE DRY-RUN v0.11.3 ===\n");
+    printf("=== SUSANIN PROMOTE DRY-RUN v%s ===\n", SUSANIN_VERSION);
     printf("RouterOS changes: NONE\n\n");
     int rc = verify_stage(ros, &desired);
     if (rc == 0) {
@@ -314,7 +315,7 @@ int promote_run(ros_client_t *ros, const app_config_t *cfg) {
     susanin_render_bundle_t desired;
     if (renderer_build(ros, cfg, &desired) < 0) return -1;
 
-    printf("=== SUSANIN PROMOTE v0.11.3 ===\n");
+    printf("=== SUSANIN PROMOTE v%s ===\n", SUSANIN_VERSION);
     printf("Transactional source promotion with automatic rollback on failure.\n\n");
 
     if (verify_stage(ros, &desired) < 0) {
@@ -399,7 +400,7 @@ fail_pre:
 }
 
 int rollback_run(ros_client_t *ros) {
-    printf("=== SUSANIN ROLLBACK v0.11.3 ===\n");
+    printf("=== SUSANIN ROLLBACK v%s ===\n", SUSANIN_VERSION);
     script_obj_t prod[MANAGED_COUNT];
     script_obj_t backup[MANAGED_COUNT];
     scheduler_obj_t sched[MANAGED_COUNT];

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -1,5 +1,6 @@
 #include "renderer.h"
 #include "fingerprint.h"
+#include "version.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -276,7 +277,7 @@ void renderer_free(susanin_render_bundle_t *bundle) {
 int renderer_run(ros_client_t *ros, const app_config_t *cfg) {
     susanin_render_bundle_t b;
     if (renderer_build(ros, cfg, &b) < 0) return -1;
-    printf("=== SUSANIN RENDER v0.11.3 ===\n");
+    printf("=== SUSANIN RENDER v%s ===\n", SUSANIN_VERSION);
     printf("Mode: generated desired RouterOS data-plane; no changes\n");
     printf("LAN interface-list: %s\n", cfg->lan_list);
     printf("LAN IPv4 networks discovered: %u\n", b.lan_networks);

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -132,6 +132,29 @@ static char *lan_match_snippet(const render_ctx_t *ctx) {
     return buf;
 }
 
+static int log_level_rank(const char *level) {
+    if (!level) return 2;
+
+    if (strcmp(level, "quiet") == 0) return 0;
+    if (strcmp(level, "error") == 0) return 1;
+    if (strcmp(level, "info") == 0) return 2;
+    if (strcmp(level, "debug") == 0) return 3;
+    if (strcmp(level, "trace") == 0) return 4;
+
+    return 2;
+}
+
+static const char *log_enabled(
+    const app_config_t *cfg,
+    int required_rank
+) {
+    return log_level_rank(
+        cfg ? cfg->log_level : NULL
+    ) >= required_rank
+        ? "true"
+        : "false";
+}
+
 static char *load_template(const char *name) {
     char path[512];
     snprintf(path, sizeof(path), "/usr/share/susanin/templates/%s", name);
@@ -162,10 +185,34 @@ static int render_one(const char *tmpl_name, const char *script_name,
     free(c);
     if (!d) return -1;
 
+    char *e = replace_all(
+        d,
+        "{{LOG_ERROR}}",
+        log_enabled(cfg, 1)
+    );
+    free(d);
+    if (!e) return -1;
+
+    char *f = replace_all(
+        e,
+        "{{LOG_INFO}}",
+        log_enabled(cfg, 2)
+    );
+    free(e);
+    if (!f) return -1;
+
+    char *g = replace_all(
+        f,
+        "{{LOG_DEBUG}}",
+        log_enabled(cfg, 3)
+    );
+    free(f);
+    if (!g) return -1;
+
     snprintf(out->name, sizeof(out->name), "%s", script_name);
-    out->source = d;
-    out->bytes = strlen(d);
-    susanin_fingerprint_hex(d, out->fp);
+    out->source = g;
+    out->bytes = strlen(g);
+    susanin_fingerprint_hex(g, out->fp);
     return 0;
 }
 

--- a/src/routerlog.c
+++ b/src/routerlog.c
@@ -1,0 +1,312 @@
+#include "routerlog.h"
+#include "diag.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#define ROUTERLOG_KEEP 8
+#define ROUTERLOG_TIME_MAX 64
+#define ROUTERLOG_TOPICS_MAX 128
+#define ROUTERLOG_MESSAGE_MAX 512
+
+typedef struct {
+    char time[ROUTERLOG_TIME_MAX];
+    char topics[ROUTERLOG_TOPICS_MAX];
+    char message[ROUTERLOG_MESSAGE_MAX];
+} routerlog_entry_t;
+
+typedef struct {
+    const app_config_t *cfg;
+
+    unsigned total;
+    unsigned script_errors;
+    unsigned no_such_item;
+
+    routerlog_entry_t recent[ROUTERLOG_KEEP];
+    unsigned recent_count;
+    unsigned recent_next;
+
+    char latest_no_such_time[ROUTERLOG_TIME_MAX];
+    char latest_no_such_message[ROUTERLOG_MESSAGE_MAX];
+} routerlog_ctx_t;
+
+static int contains_topic(
+    const char *topics,
+    const char *needle
+) {
+    return topics &&
+        needle &&
+        strstr(topics, needle) != NULL;
+}
+
+static void copy_text(
+    char *dst,
+    size_t dst_size,
+    const char *src
+) {
+    if (!dst || dst_size == 0) return;
+
+    if (!src) src = "";
+
+    snprintf(
+        dst,
+        dst_size,
+        "%s",
+        src
+    );
+}
+
+static void remember_error(
+    routerlog_ctx_t *ctx,
+    const char *time,
+    const char *topics,
+    const char *message
+) {
+    routerlog_entry_t *entry =
+        &ctx->recent[ctx->recent_next];
+
+    copy_text(
+        entry->time,
+        sizeof(entry->time),
+        time
+    );
+
+    copy_text(
+        entry->topics,
+        sizeof(entry->topics),
+        topics
+    );
+
+    copy_text(
+        entry->message,
+        sizeof(entry->message),
+        message
+    );
+
+    ctx->recent_next =
+        (ctx->recent_next + 1U) %
+        ROUTERLOG_KEEP;
+
+    if (ctx->recent_count < ROUTERLOG_KEEP) {
+        ++ctx->recent_count;
+    }
+}
+
+static int log_cb(
+    const ros_sentence_t *s,
+    void *opaque
+) {
+    routerlog_ctx_t *ctx = opaque;
+
+    if (!ros_is_reply(s, "!re")) {
+        return 0;
+    }
+
+    ++ctx->total;
+
+    const char *time =
+        ros_get_attr(s, "time");
+
+    const char *topics =
+        ros_get_attr(s, "topics");
+
+    const char *message =
+        ros_get_attr(s, "message");
+
+    if (!time) time = "-";
+    if (!topics) topics = "-";
+    if (!message) message = "";
+
+    int script_error =
+        (
+            contains_topic(topics, "script") &&
+            contains_topic(topics, "error")
+        ) ||
+        strstr(message, "script error") != NULL;
+
+    if (!script_error) {
+        return 0;
+    }
+
+    ++ctx->script_errors;
+
+    remember_error(
+        ctx,
+        time,
+        topics,
+        message
+    );
+
+    if (
+        strstr(
+            message,
+            "no such item"
+        ) != NULL
+    ) {
+        ++ctx->no_such_item;
+
+        copy_text(
+            ctx->latest_no_such_time,
+            sizeof(ctx->latest_no_such_time),
+            time
+        );
+
+        copy_text(
+            ctx->latest_no_such_message,
+            sizeof(ctx->latest_no_such_message),
+            message
+        );
+    }
+
+    return 0;
+}
+
+static void print_recent_errors(
+    const routerlog_ctx_t *ctx
+) {
+    if (ctx->recent_count == 0) {
+        printf(
+            "\nRecent script errors: none\n"
+        );
+        return;
+    }
+
+    printf(
+        "\nRecent script errors (%u max):\n",
+        ROUTERLOG_KEEP
+    );
+
+    unsigned start;
+
+    if (ctx->recent_count < ROUTERLOG_KEEP) {
+        start = 0;
+    } else {
+        start = ctx->recent_next;
+    }
+
+    for (
+        unsigned i = 0;
+        i < ctx->recent_count;
+        ++i
+    ) {
+        unsigned index =
+            (start + i) %
+            ROUTERLOG_KEEP;
+
+        const routerlog_entry_t *entry =
+            &ctx->recent[index];
+
+        printf(
+            "  %s topics=%s message=%s\n",
+            entry->time,
+            entry->topics,
+            entry->message
+        );
+    }
+}
+
+int routerlog_collect_errors(
+    ros_client_t *ros,
+    const app_config_t *cfg
+) {
+    if (!ros || !cfg) return -1;
+
+    routerlog_ctx_t ctx;
+    memset(&ctx, 0, sizeof(ctx));
+    ctx.cfg = cfg;
+
+    /*
+     * Do not rely on RouterOS-side
+     * topics~"script,error" filtering.
+     *
+     * RouterOS 7.23.3 was observed to return
+     * no rows for that CLI filter even when
+     * matching records had topics=script,error.
+     *
+     * Read the bounded RouterOS log and filter
+     * locally.
+     */
+    const char *cmd[] = {
+        "/log/print",
+        "=.proplist=time,topics,message"
+    };
+
+    printf(
+        "=== SUSANIN ROUTEROS SCRIPT ERRORS ===\n"
+    );
+
+    if (
+        ros_command(
+            ros,
+            cmd,
+            2,
+            log_cb,
+            &ctx
+        ) < 0
+    ) {
+        (void)diag_event(
+            cfg,
+            "telemetry_error",
+            "RouterOS log query failed"
+        );
+
+        return -1;
+    }
+
+    printf(
+        "Log records scanned : %u\n",
+        ctx.total
+    );
+
+    printf(
+        "Script errors       : %u\n",
+        ctx.script_errors
+    );
+
+    printf(
+        "no such item        : %u\n",
+        ctx.no_such_item
+    );
+
+    if (ctx.no_such_item > 0) {
+        printf(
+            "Latest no such item: %s %s\n",
+            ctx.latest_no_such_time,
+            ctx.latest_no_such_message
+        );
+    }
+
+    print_recent_errors(&ctx);
+
+    char summary[1024];
+
+    if (ctx.no_such_item > 0) {
+        snprintf(
+            summary,
+            sizeof(summary),
+            "records=%u script_errors=%u no_such_item=%u "
+            "latest_no_such_time=%s latest_no_such_message=%s",
+            ctx.total,
+            ctx.script_errors,
+            ctx.no_such_item,
+            ctx.latest_no_such_time,
+            ctx.latest_no_such_message
+        );
+    } else {
+        snprintf(
+            summary,
+            sizeof(summary),
+            "records=%u script_errors=%u no_such_item=0",
+            ctx.total,
+            ctx.script_errors
+        );
+    }
+
+    (void)diag_event(
+        cfg,
+        "routeros_error_summary",
+        summary
+    );
+
+    return 0;
+}

--- a/src/routerlog.h
+++ b/src/routerlog.h
@@ -1,0 +1,12 @@
+#ifndef SUSANIN_ROUTERLOG_H
+#define SUSANIN_ROUTERLOG_H
+
+#include "config.h"
+#include "routeros_api.h"
+
+int routerlog_collect_errors(
+    ros_client_t *ros,
+    const app_config_t *cfg
+);
+
+#endif

--- a/src/setup.c
+++ b/src/setup.c
@@ -265,7 +265,7 @@ int setup_run(ros_client_t *ros, app_config_t *cfg) {
         return -1;
     }
 
-    /* v0.11.3 bootstrap self-cleans its elevated worker after controller
+    /* The credentialless bootstrap self-cleans its elevated worker after controller
        start. Keep best-effort legacy helper cleanup here for upgrade safety;
        the restricted agent may not have permission to remove admin-owned
        elevated helpers, so correctness does not depend on these calls. */

--- a/src/stage.c
+++ b/src/stage.c
@@ -2,6 +2,7 @@
 #include "stage.h"
 #include "fingerprint.h"
 #include "renderer.h"
+#include "version.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -142,7 +143,7 @@ static int add_stage(ros_client_t *ros, const char *name, const char *source,
 int stage_clean_run(ros_client_t *ros) {
     unsigned removed = 0;
     unsigned failed = 0;
-    printf("=== SUSANIN STAGE CLEAN v0.11.3 ===\n");
+    printf("=== SUSANIN STAGE CLEAN v%s ===\n", SUSANIN_VERSION);
     for (size_t i = 0; i < STAGE_COUNT; ++i) {
         stage_obj_t o;
         if (lookup_name_exact(ros, stage_names[i], &o) < 0) {
@@ -170,7 +171,7 @@ int stage_run(ros_client_t *ros, const app_config_t *cfg) {
     susanin_render_bundle_t desired;
     if (renderer_build(ros, cfg, &desired) < 0) return -1;
 
-    printf("=== SUSANIN STAGE v0.11.3 ===\n");
+    printf("=== SUSANIN STAGE v%s ===\n", SUSANIN_VERSION);
     printf("Mode: persistent inert stage scripts; production data-plane is untouched\n");
     printf("LAN IPv4 networks: %u\n", desired.lan_networks);
     printf("Egress: %s address=%s\n", cfg->egress_interface, desired.egress_address);
@@ -193,7 +194,7 @@ int stage_run(ros_client_t *ros, const app_config_t *cfg) {
         const susanin_rendered_script_t *s = &desired.scripts[i];
         char comment[192];
         snprintf(comment, sizeof(comment),
-                 "SUSANIN:v0.11.3 staged source for %s fp=%s; DO NOT RUN",
+                 "SUSANIN:v" SUSANIN_VERSION " staged source for %s fp=%s; DO NOT RUN",
                  s->name, s->fp);
 
         if (add_stage(ros, stage_names[i], s->source, comment) < 0) {

--- a/src/telemetry.c
+++ b/src/telemetry.c
@@ -1,0 +1,495 @@
+#include "telemetry.h"
+#include "diag.h"
+
+#include <stdio.h>
+#include <string.h>
+
+typedef struct {
+    char uptime[64];
+    char version[64];
+    char cpu_load[32];
+    char free_memory[64];
+    char total_memory[64];
+    char board_name[128];
+    char architecture[64];
+    int seen;
+} resource_ctx_t;
+
+typedef struct {
+    char total_entries[64];
+    char max_entries[64];
+    int seen;
+} conntrack_ctx_t;
+
+typedef struct {
+    unsigned total;
+    unsigned managed_workers;
+    unsigned agent_jobs;
+
+    char managed_names[512];
+    size_t managed_names_used;
+
+    char all_jobs[2048];
+    size_t all_jobs_used;
+} jobs_ctx_t;
+
+static void copy_attr(
+    char *dst,
+    size_t dst_size,
+    const ros_sentence_t *s,
+    const char *name
+) {
+    const char *value = ros_get_attr(s, name);
+
+    if (!dst || dst_size == 0) return;
+
+    if (!value) {
+        dst[0] = '\0';
+        return;
+    }
+
+    snprintf(dst, dst_size, "%s", value);
+}
+
+static int resource_cb(
+    const ros_sentence_t *s,
+    void *opaque
+) {
+    resource_ctx_t *ctx = opaque;
+
+    if (!ros_is_reply(s, "!re")) return 0;
+
+    copy_attr(
+        ctx->uptime,
+        sizeof(ctx->uptime),
+        s,
+        "uptime"
+    );
+
+    copy_attr(
+        ctx->version,
+        sizeof(ctx->version),
+        s,
+        "version"
+    );
+
+    copy_attr(
+        ctx->cpu_load,
+        sizeof(ctx->cpu_load),
+        s,
+        "cpu-load"
+    );
+
+    copy_attr(
+        ctx->free_memory,
+        sizeof(ctx->free_memory),
+        s,
+        "free-memory"
+    );
+
+    copy_attr(
+        ctx->total_memory,
+        sizeof(ctx->total_memory),
+        s,
+        "total-memory"
+    );
+
+    copy_attr(
+        ctx->board_name,
+        sizeof(ctx->board_name),
+        s,
+        "board-name"
+    );
+
+    copy_attr(
+        ctx->architecture,
+        sizeof(ctx->architecture),
+        s,
+        "architecture-name"
+    );
+
+    ctx->seen = 1;
+    return 0;
+}
+
+static int conntrack_cb(
+    const ros_sentence_t *s,
+    void *opaque
+) {
+    conntrack_ctx_t *ctx = opaque;
+
+    if (!ros_is_reply(s, "!re")) return 0;
+
+    copy_attr(
+        ctx->total_entries,
+        sizeof(ctx->total_entries),
+        s,
+        "total-entries"
+    );
+
+    copy_attr(
+        ctx->max_entries,
+        sizeof(ctx->max_entries),
+        s,
+        "max-entries"
+    );
+
+    ctx->seen = 1;
+    return 0;
+}
+
+static void append_job_name(
+    char *buf,
+    size_t buf_size,
+    size_t *used,
+    const char *name
+) {
+    if (
+        !buf ||
+        !used ||
+        !name ||
+        !*name ||
+        *used >= buf_size - 1
+    ) {
+        return;
+    }
+
+    int written = snprintf(
+        buf + *used,
+        buf_size - *used,
+        "%s%s",
+        *used ? "," : "",
+        name
+    );
+
+    if (written < 0) return;
+
+    size_t added = (size_t)written;
+
+    if (added >= buf_size - *used) {
+        *used = buf_size - 1;
+    } else {
+        *used += added;
+    }
+}
+
+static int jobs_cb(
+    const ros_sentence_t *s,
+    void *opaque
+) {
+    jobs_ctx_t *ctx = opaque;
+
+    if (!ros_is_reply(s, "!re")) return 0;
+
+    ++ctx->total;
+
+    const char *script = ros_get_attr(s, "script");
+    const char *owner = ros_get_attr(s, "owner");
+    const char *type = ros_get_attr(s, "type");
+    const char *started = ros_get_attr(s, "started");
+
+    if (!script || !*script) script = "-";
+    if (!owner || !*owner) owner = "-";
+    if (!type || !*type) type = "-";
+    if (!started || !*started) started = "-";
+
+    char one_job[512];
+
+    snprintf(
+        one_job,
+        sizeof(one_job),
+        "{script=%s owner=%s type=%s started=%s}",
+        script,
+        owner,
+        type,
+        started
+    );
+
+    append_job_name(
+        ctx->all_jobs,
+        sizeof(ctx->all_jobs),
+        &ctx->all_jobs_used,
+        one_job
+    );
+
+    if (strcmp(owner, "susanin-agent") == 0) {
+        ++ctx->agent_jobs;
+    }
+
+    if (
+        strcmp(script, "-") != 0 &&
+        strncmp(script, "auto-awg-", 9) == 0
+    ) {
+        ++ctx->managed_workers;
+
+        append_job_name(
+            ctx->managed_names,
+            sizeof(ctx->managed_names),
+            &ctx->managed_names_used,
+            script
+        );
+    }
+
+    return 0;
+}
+
+static int collect_resource(
+    ros_client_t *ros,
+    const app_config_t *cfg
+) {
+    resource_ctx_t ctx;
+    memset(&ctx, 0, sizeof(ctx));
+
+    const char *cmd[] = {
+        "/system/resource/print",
+        "=.proplist=uptime,version,cpu-load,"
+        "free-memory,total-memory,"
+        "board-name,architecture-name"
+    };
+
+    if (
+        ros_command(
+            ros,
+            cmd,
+            2,
+            resource_cb,
+            &ctx
+        ) < 0
+    ) {
+        (void)diag_event(
+            cfg,
+            "telemetry_error",
+            "system resource query failed"
+        );
+
+        return -1;
+    }
+
+    if (!ctx.seen) {
+        (void)diag_event(
+            cfg,
+            "telemetry_error",
+            "system resource query returned no data"
+        );
+
+        return -1;
+    }
+
+    char msg[768];
+
+    snprintf(
+        msg,
+        sizeof(msg),
+        "cpu_load=%s "
+        "free_memory=%s "
+        "total_memory=%s "
+        "uptime=%s "
+        "version=%s "
+        "board=%s "
+        "arch=%s",
+        ctx.cpu_load[0] ? ctx.cpu_load : "?",
+        ctx.free_memory[0] ? ctx.free_memory : "?",
+        ctx.total_memory[0] ? ctx.total_memory : "?",
+        ctx.uptime[0] ? ctx.uptime : "?",
+        ctx.version[0] ? ctx.version : "?",
+        ctx.board_name[0] ? ctx.board_name : "?",
+        ctx.architecture[0] ? ctx.architecture : "?"
+    );
+
+    printf(
+        "Resource: CPU=%s%% free-memory=%s "
+        "total-memory=%s uptime=%s\n",
+        ctx.cpu_load[0] ? ctx.cpu_load : "?",
+        ctx.free_memory[0] ? ctx.free_memory : "?",
+        ctx.total_memory[0] ? ctx.total_memory : "?",
+        ctx.uptime[0] ? ctx.uptime : "?"
+    );
+
+    return diag_event(
+        cfg,
+        "router_metrics",
+        msg
+    );
+}
+
+static int collect_conntrack(
+    ros_client_t *ros,
+    const app_config_t *cfg
+) {
+    conntrack_ctx_t ctx;
+    memset(&ctx, 0, sizeof(ctx));
+
+    const char *cmd[] = {
+        "/ip/firewall/connection/tracking/print",
+        "=.proplist=total-entries,max-entries"
+    };
+
+    if (
+        ros_command(
+            ros,
+            cmd,
+            2,
+            conntrack_cb,
+            &ctx
+        ) < 0
+    ) {
+        (void)diag_event(
+            cfg,
+            "telemetry_error",
+            "connection tracking metrics query failed"
+        );
+
+        return -1;
+    }
+
+    if (!ctx.seen) {
+        (void)diag_event(
+            cfg,
+            "telemetry_error",
+            "connection tracking metrics returned no data"
+        );
+
+        return -1;
+    }
+
+    char msg[256];
+
+    snprintf(
+        msg,
+        sizeof(msg),
+        "total_entries=%s max_entries=%s",
+        ctx.total_entries[0]
+            ? ctx.total_entries
+            : "?",
+        ctx.max_entries[0]
+            ? ctx.max_entries
+            : "?"
+    );
+
+    printf(
+        "Conntrack: total=%s max=%s\n",
+        ctx.total_entries[0]
+            ? ctx.total_entries
+            : "?",
+        ctx.max_entries[0]
+            ? ctx.max_entries
+            : "?"
+    );
+
+    return diag_event(
+        cfg,
+        "conntrack_metrics",
+        msg
+    );
+}
+
+static int collect_jobs(
+    ros_client_t *ros,
+    const app_config_t *cfg
+) {
+    jobs_ctx_t ctx;
+    memset(&ctx, 0, sizeof(ctx));
+
+    const char *cmd[] = {
+        "/system/script/job/print",
+        "=.proplist=script,owner,type,started"
+    };
+
+    if (
+        ros_command(
+            ros,
+            cmd,
+            2,
+            jobs_cb,
+            &ctx
+        ) < 0
+    ) {
+        (void)diag_event(
+            cfg,
+            "telemetry_error",
+            "script job query failed"
+        );
+
+        return -1;
+    }
+
+    char msg[4096];
+
+    snprintf(
+        msg,
+        sizeof(msg),
+        "total=%u managed_workers=%u agent_jobs=%u "
+        "managed=%s jobs=%s",
+        ctx.total,
+        ctx.managed_workers,
+        ctx.agent_jobs,
+        ctx.managed_names[0]
+            ? ctx.managed_names
+            : "-",
+        ctx.all_jobs[0]
+            ? ctx.all_jobs
+            : "-"
+    );
+
+    printf(
+        "Script jobs: total=%u managed-workers=%u agent-jobs=%u\n",
+        ctx.total,
+        ctx.managed_workers,
+        ctx.agent_jobs
+    );
+
+    printf(
+        "  Workers: %s\n",
+        ctx.managed_names[0]
+            ? ctx.managed_names
+            : "-"
+    );
+
+    printf(
+        "  Jobs   : %s\n",
+        ctx.all_jobs[0]
+            ? ctx.all_jobs
+            : "-"
+    );
+
+    return diag_event(
+        cfg,
+        "script_jobs",
+        msg
+    );
+}
+
+int telemetry_collect_once(
+    ros_client_t *ros,
+    const app_config_t *cfg
+) {
+    if (!ros || !cfg) return -1;
+
+    printf(
+        "=== SUSANIN ROUTEROS TELEMETRY ===\n"
+    );
+
+    int failed = 0;
+
+    if (collect_resource(ros, cfg) < 0) {
+        failed = 1;
+    }
+
+    if (collect_conntrack(ros, cfg) < 0) {
+        failed = 1;
+    }
+
+    if (collect_jobs(ros, cfg) < 0) {
+        failed = 1;
+    }
+
+    if (failed) {
+        printf(
+            "Telemetry result: PARTIAL/FAILED\n"
+        );
+        return -1;
+    }
+
+    printf("Telemetry result: OK\n");
+    return 0;
+}

--- a/src/telemetry.h
+++ b/src/telemetry.h
@@ -1,0 +1,12 @@
+#ifndef SUSANIN_TELEMETRY_H
+#define SUSANIN_TELEMETRY_H
+
+#include "config.h"
+#include "routeros_api.h"
+
+int telemetry_collect_once(
+    ros_client_t *ros,
+    const app_config_t *cfg
+);
+
+#endif

--- a/src/validate.c
+++ b/src/validate.c
@@ -2,6 +2,7 @@
 #include "validate.h"
 #include "fingerprint.h"
 #include "renderer.h"
+#include "version.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -138,7 +139,7 @@ int validate_run(ros_client_t *ros, const app_config_t *cfg) {
     susanin_render_bundle_t desired;
     if (renderer_build(ros, cfg, &desired) < 0) return -1;
 
-    printf("=== SUSANIN VALIDATE v0.11.3 ===\n");
+    printf("=== SUSANIN VALIDATE v%s ===\n", SUSANIN_VERSION);
     printf("Mode: unique temporary RouterOS script objects; production data-plane is untouched\n");
     printf("LAN IPv4 networks: %u\n", desired.lan_networks);
     printf("Egress: %s address=%s\n", cfg->egress_interface, desired.egress_address);

--- a/src/version.h
+++ b/src/version.h
@@ -1,0 +1,6 @@
+#ifndef SUSANIN_VERSION_H
+#define SUSANIN_VERSION_H
+
+#define SUSANIN_VERSION "0.11.4-rc1"
+
+#endif

--- a/templates/fast.rsc.tmpl
+++ b/templates/fast.rsc.tmpl
@@ -1,7 +1,7 @@
-:if ([/system script job print count-only as-value where script=[:jobname]] > 1) do={ :return }
+:if ([/system script job print count-only as-value where script=[:jobname]] > 1) do={ :exit }
 :local healthRule [/ip firewall mangle find where comment="AUTO-AWG: L1 mark test"]
-:if ([:len $healthRule] = 0) do={ :return }
-:if ([/ip firewall mangle get $healthRule disabled] = true) do={ :return }
+:if ([:len $healthRule] = 0) do={ :exit }
+:if ([/ip firewall mangle get $healthRule disabled] = true) do={ :exit }
 :foreach c in=[/ip firewall connection print as-value where protocol=tcp and tcp-state=syn-sent] do={
   :local id ($c->".id"); :local src [:toip ($c->"src-address")]; :local dst [:toip ($c->"dst-address")]; :local port ($c->"dst-port")
   :local mark [:tostr ($c->"connection-mark")]; :local op ($c->"orig-packets"); :local rp ($c->"repl-packets")

--- a/templates/fast.rsc.tmpl
+++ b/templates/fast.rsc.tmpl
@@ -11,7 +11,7 @@
       :if (([:len [/ip firewall address-list find where list="auto_awg_ok_tcp" and address=$dst]] = 0) && ([:len [/ip firewall address-list find where list="auto_awg_test_tcp" and address=$dst]] = 0) && ([:len [/ip firewall address-list find where list="auto_awg_cooldown_tcp" and address=$dst]] = 0)) do={
         /ip firewall address-list remove [find where list="auto_awg_watch_tcp" and address=$dst]
         /ip firewall address-list add list=auto_awg_test_tcp address=$dst timeout=1m comment=("FAST TCP-SYN " . [:tostr $port])
-        :log warning ("AUTO-AWG: FAST TCP-SYN " . [:tostr $dst] . ":" . [:tostr $port])
+        :if ({{LOG_DEBUG}}) do={ :log warning ("AUTO-AWG: FAST TCP-SYN " . [:tostr $dst] . ":" . [:tostr $port]) }
         :onerror err in={ /ip firewall connection remove $id } do={}
       }
     }
@@ -26,7 +26,7 @@
       :if (([:len [/ip firewall address-list find where list="auto_awg_ok_tcp" and address=$dst]] = 0) && ([:len [/ip firewall address-list find where list="auto_awg_test_tcp" and address=$dst]] = 0) && ([:len [/ip firewall address-list find where list="auto_awg_cooldown_tcp" and address=$dst]] = 0)) do={
         /ip firewall address-list remove [find where list="auto_awg_watch_tcp" and address=$dst]
         /ip firewall address-list add list=auto_awg_test_tcp address=$dst timeout=1m comment=("FAST TCP-CLOSE " . [:tostr $port])
-        :log warning ("AUTO-AWG: FAST TCP-CLOSE " . [:tostr $dst] . ":" . [:tostr $port])
+        :if ({{LOG_DEBUG}}) do={ :log warning ("AUTO-AWG: FAST TCP-CLOSE " . [:tostr $dst] . ":" . [:tostr $port]) }
         :onerror err in={ /ip firewall connection remove $id } do={}
       }
     }
@@ -41,7 +41,7 @@
       :if (([:len [/ip firewall address-list find where list="auto_awg_ok_udp" and address=$dst]] = 0) && ([:len [/ip firewall address-list find where list="auto_awg_test_udp" and address=$dst]] = 0) && ([:len [/ip firewall address-list find where list="auto_awg_cooldown_udp" and address=$dst]] = 0)) do={
         /ip firewall address-list remove [find where list="auto_awg_watch_udp" and address=$dst]
         /ip firewall address-list add list=auto_awg_test_udp address=$dst timeout=1m comment="FAST QUIC 443"
-        :log warning ("AUTO-AWG: FAST QUIC " . [:tostr $dst] . ":443")
+        :if ({{LOG_DEBUG}}) do={ :log warning ("AUTO-AWG: FAST QUIC " . [:tostr $dst] . ":443") }
         :onerror err in={ /ip firewall connection remove $id } do={}
       }
     }

--- a/templates/health.rsc.tmpl
+++ b/templates/health.rsc.tmpl
@@ -35,7 +35,7 @@
         }
       }
     }
-    :log info ("AUTO-AWG: tunnel UP, recovery TCP=" . [:tostr $recoveredTCP] . " UDP=" . [:tostr $recoveredUDP])
+    :if ({{LOG_INFO}}) do={ :log info ("AUTO-AWG: tunnel UP, recovery TCP=" . [:tostr $recoveredTCP] . " UDP=" . [:tostr $recoveredUDP]) }
   }
   :return
 }
@@ -53,4 +53,4 @@
 /ip firewall address-list remove [find where list="auto_awg_test_tcp"]
 /ip firewall address-list remove [find where list="auto_awg_watch_udp"]
 /ip firewall address-list remove [find where list="auto_awg_test_udp"]
-:log warning "AUTO-AWG: tunnel DOWN after 2 health misses, fallback to DIRECT"
+:if ({{LOG_ERROR}}) do={ :log warning "AUTO-AWG: tunnel DOWN after 2 health misses, fallback to DIRECT" }

--- a/templates/health.rsc.tmpl
+++ b/templates/health.rsc.tmpl
@@ -1,8 +1,8 @@
-:if ([/system script job print count-only as-value where script=[:jobname]] > 1) do={ :return }
+:if ([/system script job print count-only as-value where script=[:jobname]] > 1) do={ :exit }
 :local healthRule [/ip firewall mangle find where comment="AUTO-AWG: L1 mark test"]
-:if ([:len $healthRule] = 0) do={ :return }
+:if ([:len $healthRule] = 0) do={ :exit }
 :local awgAddrId [/ip address find where interface="{{EGRESS_INTERFACE}}"]
-:if ([:len $awgAddrId] = 0) do={ :return }
+:if ([:len $awgAddrId] = 0) do={ :exit }
 :local awgCIDR [/ip address get $awgAddrId address]
 :local awgIP [:toip [:pick $awgCIDR 0 [:find $awgCIDR "/"]]]
 :local p1 [/ping address=1.1.1.1 interface="{{EGRESS_INTERFACE}}" src-address=$awgIP count=1]
@@ -37,13 +37,13 @@
     }
     :if ({{LOG_INFO}}) do={ :log info ("AUTO-AWG: tunnel UP, recovery TCP=" . [:tostr $recoveredTCP] . " UDP=" . [:tostr $recoveredUDP]) }
   }
-  :return
+  :exit
 }
-:if ($isDisabled = true) do={ :return }
+:if ($isDisabled = true) do={ :exit }
 :local failId [/ip firewall address-list find where list="auto_awg_health_fail" and address=$awgIP]
 :if ([:len $failId] = 0) do={
   /ip firewall address-list add list=auto_awg_health_fail address=$awgIP timeout=8s comment="AWG health miss 1/2"
-  :return
+  :exit
 }
 /ip firewall address-list remove [find where list="auto_awg_health_fail"]
 /ip firewall mangle disable [find where comment~"^AUTO-AWG:"]

--- a/templates/judge.rsc.tmpl
+++ b/templates/judge.rsc.tmpl
@@ -26,7 +26,7 @@
       :if ($good = true) do={
         :if ([:len [/ip firewall address-list find where list=$okList and address=$dst]] = 0) do={
           /ip firewall address-list add list=$okList address=$dst timeout=6h comment=("AUTO confirmed " . $proto . ":" . [:tostr $port])
-          :log info ("AUTO-AWG: CONFIRMED " . [:tostr $dst] . " via " . $proto . ":" . [:tostr $port])
+          :if ({{LOG_INFO}}) do={ :log info ("AUTO-AWG: CONFIRMED " . [:tostr $dst] . " via " . $proto . ":" . [:tostr $port]) }
         }
         /ip firewall address-list remove [find where list=$testList and address=$dst]
         /ip firewall address-list remove [find where list=$watchList and address=$dst]

--- a/templates/judge.rsc.tmpl
+++ b/templates/judge.rsc.tmpl
@@ -1,7 +1,7 @@
-:if ([/system script job print count-only as-value where script=[:jobname]] > 1) do={ :return }
+:if ([/system script job print count-only as-value where script=[:jobname]] > 1) do={ :exit }
 :local healthRule [/ip firewall mangle find where comment="AUTO-AWG: L1 mark test"]
-:if ([:len $healthRule] = 0) do={ :return }
-:if ([/ip firewall mangle get $healthRule disabled] = true) do={ :return }
+:if ([:len $healthRule] = 0) do={ :exit }
+:if ([/ip firewall mangle get $healthRule disabled] = true) do={ :exit }
 :foreach c in=[/ip firewall connection print as-value where connection-mark=auto-awg-test-conn] do={
   :local id ($c->".id"); :local src [:toip ($c->"src-address")]; :local dst [:toip ($c->"dst-address")]; :local port ($c->"dst-port"); :local proto [:tostr ($c->"protocol")]
   :local op ($c->"orig-packets"); :local rp ($c->"repl-packets"); :local ob ($c->"orig-bytes"); :local rb ($c->"repl-bytes")

--- a/templates/soft.rsc.tmpl
+++ b/templates/soft.rsc.tmpl
@@ -22,8 +22,10 @@
             /ip firewall address-list add list=auto_awg_watch_tcp address=$dst timeout=8s comment=("TCP-LATE-STALL " . [:tostr $port])
           }
         } else={
-          :local left [/ip firewall address-list get $wid timeout]
-          :if ($left <= 4s) do={ :set trigger true; :set reason "TCP-LATE-STALL" }
+          :onerror err in={
+            :local left [/ip firewall address-list get $wid timeout]
+            :if ($left <= 4s) do={ :set trigger true; :set reason "TCP-LATE-STALL" }
+          } do={}
         }
       }
       :if ($trigger = true) do={
@@ -67,15 +69,17 @@
           /ip firewall address-list add list=auto_awg_watch_udp address=$dst timeout=8s comment="QUIC-LATE-STALL 443"
         }
       } else={
-        :local left [/ip firewall address-list get $wid timeout]
-        :if ($left <= 4s) do={
-          :if (([:len [/ip firewall address-list find where list="auto_awg_ok_udp" and address=$dst]] = 0) && ([:len [/ip firewall address-list find where list="auto_awg_test_udp" and address=$dst]] = 0) && ([:len [/ip firewall address-list find where list="auto_awg_cooldown_udp" and address=$dst]] = 0)) do={
-            /ip firewall address-list remove $wid
-            /ip firewall address-list add list=auto_awg_test_udp address=$dst timeout=1m comment="QUIC-LATE-STALL 443"
-            :if ({{LOG_DEBUG}}) do={ :log warning ("AUTO-AWG: SOFT QUIC-LATE-STALL " . [:tostr $dst] . ":443") }
-            :onerror err in={ /ip firewall connection remove $id } do={}
+        :onerror err in={
+          :local left [/ip firewall address-list get $wid timeout]
+          :if ($left <= 4s) do={
+            :if (([:len [/ip firewall address-list find where list="auto_awg_ok_udp" and address=$dst]] = 0) && ([:len [/ip firewall address-list find where list="auto_awg_test_udp" and address=$dst]] = 0) && ([:len [/ip firewall address-list find where list="auto_awg_cooldown_udp" and address=$dst]] = 0)) do={
+              /ip firewall address-list remove [find where list="auto_awg_watch_udp" and address=$dst]
+              /ip firewall address-list add list=auto_awg_test_udp address=$dst timeout=1m comment="QUIC-LATE-STALL 443"
+              :if ({{LOG_DEBUG}}) do={ :log warning ("AUTO-AWG: SOFT QUIC-LATE-STALL " . [:tostr $dst] . ":443") }
+              :onerror err in={ /ip firewall connection remove $id } do={}
+            }
           }
-        }
+        } do={}
       }
     }
   }

--- a/templates/soft.rsc.tmpl
+++ b/templates/soft.rsc.tmpl
@@ -30,7 +30,7 @@
         :if (([:len [/ip firewall address-list find where list="auto_awg_ok_tcp" and address=$dst]] = 0) && ([:len [/ip firewall address-list find where list="auto_awg_test_tcp" and address=$dst]] = 0) && ([:len [/ip firewall address-list find where list="auto_awg_cooldown_tcp" and address=$dst]] = 0)) do={
           /ip firewall address-list remove [find where list="auto_awg_watch_tcp" and address=$dst]
           /ip firewall address-list add list=auto_awg_test_tcp address=$dst timeout=1m comment=($reason . " " . [:tostr $port])
-          :log warning ("AUTO-AWG: SOFT " . $reason . " " . [:tostr $dst] . ":" . [:tostr $port])
+          :if ({{LOG_DEBUG}}) do={ :log warning ("AUTO-AWG: SOFT " . $reason . " " . [:tostr $dst] . ":" . [:tostr $port]) }
           :onerror err in={ /ip firewall connection remove $id } do={}
         }
       }
@@ -46,7 +46,7 @@
       :if (([:len [/ip firewall address-list find where list="auto_awg_ok_udp" and address=$dst]] = 0) && ([:len [/ip firewall address-list find where list="auto_awg_test_udp" and address=$dst]] = 0) && ([:len [/ip firewall address-list find where list="auto_awg_cooldown_udp" and address=$dst]] = 0)) do={
         /ip firewall address-list remove [find where list="auto_awg_watch_udp" and address=$dst]
         /ip firewall address-list add list=auto_awg_test_udp address=$dst timeout=1m comment=("UDP " . [:tostr $port])
-        :log warning ("AUTO-AWG: SOFT UDP " . [:tostr $dst] . ":" . [:tostr $port])
+        :if ({{LOG_DEBUG}}) do={ :log warning ("AUTO-AWG: SOFT UDP " . [:tostr $dst] . ":" . [:tostr $port]) }
         :onerror err in={ /ip firewall connection remove $id } do={}
       }
     }
@@ -72,7 +72,7 @@
           :if (([:len [/ip firewall address-list find where list="auto_awg_ok_udp" and address=$dst]] = 0) && ([:len [/ip firewall address-list find where list="auto_awg_test_udp" and address=$dst]] = 0) && ([:len [/ip firewall address-list find where list="auto_awg_cooldown_udp" and address=$dst]] = 0)) do={
             /ip firewall address-list remove $wid
             /ip firewall address-list add list=auto_awg_test_udp address=$dst timeout=1m comment="QUIC-LATE-STALL 443"
-            :log warning ("AUTO-AWG: SOFT QUIC-LATE-STALL " . [:tostr $dst] . ":443")
+            :if ({{LOG_DEBUG}}) do={ :log warning ("AUTO-AWG: SOFT QUIC-LATE-STALL " . [:tostr $dst] . ":443") }
             :onerror err in={ /ip firewall connection remove $id } do={}
           }
         }

--- a/templates/soft.rsc.tmpl
+++ b/templates/soft.rsc.tmpl
@@ -1,7 +1,7 @@
-:if ([/system script job print count-only as-value where script=[:jobname]] > 1) do={ :return }
+:if ([/system script job print count-only as-value where script=[:jobname]] > 1) do={ :exit }
 :local healthRule [/ip firewall mangle find where comment="AUTO-AWG: L1 mark test"]
-:if ([:len $healthRule] = 0) do={ :return }
-:if ([/ip firewall mangle get $healthRule disabled] = true) do={ :return }
+:if ([:len $healthRule] = 0) do={ :exit }
+:if ([/ip firewall mangle get $healthRule disabled] = true) do={ :exit }
 :foreach c in=[/ip firewall connection print as-value where protocol=tcp and tcp-state=established] do={
   :local id ($c->".id"); :local src [:toip ($c->"src-address")]; :local dst [:toip ($c->"dst-address")]; :local port ($c->"dst-port")
   :local mark [:tostr ($c->"connection-mark")]; :local op ($c->"orig-packets"); :local rp ($c->"repl-packets"); :local ob ($c->"orig-bytes"); :local rb ($c->"repl-bytes")


### PR DESCRIPTION
## Summary

Prepare the Susanin v0.11.4-rc1 release candidate.

This PR collects the changes accumulated after the v0.11.3 public pilot baseline and prepares the first release candidate workflow.

## Included changes

### Runtime and diagnostics

- persistent runtime configuration;
- configurable RouterOS log levels;
- diagnostic recorder with bounded rotation;
- RouterOS telemetry collection;
- RouterOS error diagnostics through `diag errors`.

### RouterOS safety improvements

- replace unsafe bare `:return` script exits with `:exit`;
- guard transient RouterOS dynamic object handling;
- improve diagnostics around disappearing objects.

### Release engineering

- centralize release version handling;
- validate release tag consistency against source version and bootstrap;
- prepare bootstrap/install scripts for `v0.11.4-rc1`;
- update RC documentation and validation notes.

## Validation performed

Reference platform:

- MikroTik ARM64;
- RouterOS 7.23.3;
- route-based AmneziaWG/WireGuard egress.

Validated:

- clean uninstall of v0.11.3 from restored configuration;
- Susanin cleanup without affecting external VPN routing;
- diagnostics start/stop/sample;
- RouterOS telemetry;
- stage/validate/promote workflow.

## Known issues

- RouterOS dynamic `/ip firewall connection` access may still produce `no such item (4)`.
- Investigation continues in #1.

## Field validation completed

The exact GitHub-generated v0.11.4-rc1 assets were validated on the reference ARM64 RouterOS 7.23.3 router.

Completed:

- fresh credentialless install;
- generated script validation (`PASS=4 FAIL=0`);
- adaptive TCP/UDP learning;
- tunnel DOWN fail-open DIRECT;
- tunnel UP recovery;
- reboot persistence;
- full uninstall;
- external AmneziaWG and `r_to_awg` preservation;
- reinstall using the same release assets;
- soak testing with stable CPU, memory and scheduler operation.

Known issue:

- intermittent RouterOS `no such item (4)` remains reproducible during normal operation;
- the data plane continues operating despite these errors;
- investigation remains open in #1.

This PR remains draft and should not be merged until the remaining known issue is evaluated for release policy.